### PR TITLE
SSLClient tightLoop fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 1.0.1
+version = 1.0.2-SNAPSHOT
 

--- a/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
+++ b/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
@@ -184,15 +184,15 @@ public class SSLClient extends TCPClient implements Reader{
         select.select(100);
       }
       channel.register(select, 0);
-
-      while(hs == NEED_UNWRAP ) {
+      
+      if(hs == NEED_UNWRAP ) {
         hs = doHandShakeRead(netDataBuffer, ePeerAppData, ssle, channel);
         if(hs == NEED_TASK) {
           runTasks();
           hs = ssle.getHandshakeStatus();
         }
       }
-      while(hs ==  NEED_WRAP) {
+      if(hs ==  NEED_WRAP) {
         hs = doHandShakeWrite(appDataBuffer, eNetworkData, ssle, channel);
         if(hs == NEED_TASK) {
           runTasks();

--- a/src/test/java/org/threadly/litesockets/tcp/SSLTests.java
+++ b/src/test/java/org/threadly/litesockets/tcp/SSLTests.java
@@ -111,7 +111,22 @@ public class SSLTests {
     assertEquals(TCPTests.SMALL_TEXT, st);
     
   }
-  
+
+  @Test
+  public void sslClientTimeout() throws IOException {
+    TCPServer server = new TCPServer("localhost", port);
+    serverFC.addTCPServer(server);
+    long start = System.currentTimeMillis();
+    try {
+      final SSLClient client = new SSLClient("localhost", port, this.sslCtx.createSSLEngine("localhost", port), 200);
+      fail();
+    } catch(IOException e) {
+      assertTrue(System.currentTimeMillis()-start > 200);
+      System.out.println(System.currentTimeMillis()-start );
+    }
+    server.close();
+  }
+
   @Test
   public void largeWriteTest() throws IOException {
     


### PR DESCRIPTION
If you tried to connect an sslClient to a non ssl server it would never timeout the handshake and end up in an infinite loop.