### PR TITLE
Fix ssl auto handshake

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 1.0.2
+version = 1.1.0-SNAPSHOT
 

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
@@ -114,6 +115,8 @@ public class NoThreadSocketExecuter extends SocketExecuterBase {
               } catch (ClosedChannelException e) {
                 removeServer(server);
                 server.close();
+              } catch(ClosedSelectorException e) {
+                
               }
             }
           }});
@@ -184,6 +187,8 @@ public class NoThreadSocketExecuter extends SocketExecuterBase {
 
   @Override
   protected void shutdownService() {
+    selector.wakeup();
+    selector.wakeup();
     try {
       if(selector != null && selector.isOpen()) {
         selector.close();
@@ -244,6 +249,8 @@ public class NoThreadSocketExecuter extends SocketExecuterBase {
         }
       } catch (IOException e) {
 
+      } catch(ClosedSelectorException e) {
+        
       }
       try {
         scheduler.tick(null);

--- a/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
+++ b/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
@@ -424,10 +424,12 @@ public class SSLClient extends TCPClient implements Reader{
   private void processHandshake(HandshakeStatus status) {
     switch(status) {
     case FINISHED: {
-      if(this.finishedHandshake.compareAndSet(false, true)){
-        writeForce(ByteBuffer.allocate(0));
-        if(!handshakeFuture.isDone()) {
-          handshakeFuture.setResult(ssle.getSession());
+      synchronized(tmpWriteBuffers) {
+        if(this.finishedHandshake.compareAndSet(false, true)){
+          writeForce(ByteBuffer.allocate(0));
+          if(!handshakeFuture.isDone()) {
+            handshakeFuture.setResult(ssle.getSession());
+          }
         }
       }
     } break;

--- a/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
+++ b/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
@@ -15,16 +15,24 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.threadly.concurrent.SubmitterExecutorInterface;
+import org.threadly.concurrent.future.ListenableFuture;
+import org.threadly.concurrent.future.SettableListenableFuture;
 import org.threadly.litesockets.Client;
+import org.threadly.litesockets.SocketExecuterBase;
 import org.threadly.litesockets.Client.Reader;
 import org.threadly.litesockets.utils.MergedByteBuffers;
 import org.threadly.util.Clock;
@@ -43,9 +51,12 @@ public class SSLClient extends TCPClient implements Reader{
   private static final SSLContext OPEN_SSL_CTX; 
 
   private final MergedByteBuffers decryptedReadList = new MergedByteBuffers();
-  private final SSLEngine ssle;
+  public final MergedByteBuffers tmpWriteBuffers = new MergedByteBuffers();
+  public final SSLEngine ssle;
+  private final SettableListenableFuture<SSLSession> handshakeFuture = new SettableListenableFuture<SSLSession>();
+  private final AtomicBoolean doneHandshake = new AtomicBoolean(false);
+  private volatile long handShakeStart = -1;
   
-  private ByteBuffer tmpAppBuffer;
   private ByteBuffer writeBuffer;
   
   private final ByteBuffer encryptedReadBuffer;
@@ -78,24 +89,36 @@ public class SSLClient extends TCPClient implements Reader{
   }
 
   public SSLClient(String host, int port, SSLEngine ssle, int timeout) throws IOException {
+    this(host, port, ssle, TCPClient.DEFAULT_SOCKET_TIMEOUT, true);
+  }
+  
+  public SSLClient(String host, int port, SSLEngine ssle, int timeout, boolean doHandshake) throws IOException {
     super(host, port, timeout);
     this.ssle = ssle;
     ssle.setUseClientMode(true);
-    doHandShake();
+    if(doHandshake) {
+      doHandShake();
+    }
     super.setReader(this);
-    encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize());
+    encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize()+50);
   }
 
   public SSLClient(SocketChannel client, SSLEngine ssle, boolean clientSSL) throws IOException {
+    this(client, ssle, clientSSL, true);
+  }
+  
+  public SSLClient(SocketChannel client, SSLEngine ssle, boolean clientSSL, boolean doHandshake) throws IOException {
     super(client);
     this.ssle = ssle;
     ssle.setUseClientMode(clientSSL);
-    doHandShake();
+    if(doHandshake) {
+      doHandShake();
+    }
     super.setReader(this);
-    encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize());
+    encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize()+50);
   }
 
-  public SSLClient(TCPClient client, SSLEngine ssle, boolean clientSSL) throws IOException {
+  public SSLClient(TCPClient client, SSLEngine ssle, boolean clientSSL, boolean doHandshake) throws IOException {
     super(client.getChannel());
     if(client.getReadBufferSize() > 0 || client.getWriteBufferSize() > 0) {
       throw new IllegalStateException("Can not add a TCPClient with pending Reads or Writes!");
@@ -108,9 +131,11 @@ public class SSLClient extends TCPClient implements Reader{
     setReader(client.getReader());
     this.ssle = ssle;
     ssle.setUseClientMode(clientSSL);
-    doHandShake();
+    if(doHandshake) {
+      doHandShake();
+    }
     super.setReader(this);
-    encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize());
+    encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize()+50);
   }
   
   private ByteBuffer getDecryptedByteBuffer() {
@@ -120,89 +145,52 @@ public class SSLClient extends TCPClient implements Reader{
     return decryptedReadBuffer;
   }
   
-  private static SSLEngineResult.HandshakeStatus doHandShakeRead(ByteBuffer networkDataBuffer, ByteBuffer peerData, SSLEngine ssle, SocketChannel channel) throws IOException {
-    peerData.clear();
-    SSLEngineResult.HandshakeStatus hs;
-    if (channel.read(networkDataBuffer) < 0) {
-      //Got close
-      throw new SSLHandshakeException(SSL_HANDSHAKE_ERROR);
+  public boolean isEncrypted() {
+    if(doneHandshake.get() && ssle.getSession().getProtocol().equals("NONE")) {
+      return false;
     }
-    networkDataBuffer.flip();
-    SSLEngineResult res = ssle.unwrap(networkDataBuffer, peerData);
-    networkDataBuffer.compact();
-    hs = res.getHandshakeStatus();
-    if(res.getStatus() != SSLEngineResult.Status.OK  && 
-        res.getStatus() != SSLEngineResult.Status.BUFFER_UNDERFLOW) {
-      throw new SSLHandshakeException(SSL_HANDSHAKE_ERROR+":"+res.getStatus());
-    }
-    return hs;
-  } 
-  
-  private static SSLEngineResult.HandshakeStatus doHandShakeWrite(ByteBuffer appBuffer, ByteBuffer networkData, SSLEngine ssle, SocketChannel channel) throws IOException {
-    networkData.clear();
-    SSLEngineResult.HandshakeStatus hs;
-    SSLEngineResult res = ssle.wrap(appBuffer, networkData);
-    hs = res.getHandshakeStatus();
-    
-    if(res.getStatus() == SSLEngineResult.Status.OK) {
-      networkData.flip();
-      while (networkData.hasRemaining()) {
-        if (channel.write(networkData) < 0) {
-          throw new SSLHandshakeException(SSL_HANDSHAKE_ERROR);
-        }
-      }
-    } else {
-      throw new SSLHandshakeException(SSL_HANDSHAKE_ERROR+":"+res.getStatus());
-    }
-    return hs;
+    return true;
   }
   
-  
-  private void doHandShake() throws IOException {
-    ByteBuffer appDataBuffer = ByteBuffer.allocate(ssle.getSession().getApplicationBufferSize());
-    ByteBuffer netDataBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize());
-    
-    ByteBuffer eNetworkData = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize());
-    ByteBuffer ePeerAppData = ByteBuffer.allocate(ssle.getSession().getApplicationBufferSize());
-    
-    //Start the handShake
-    ssle.beginHandshake();
-    SSLEngineResult.HandshakeStatus hs = ssle.getHandshakeStatus();
-    Selector select = Selector.open();
-    
-    while (hs != FINISHED && hs != NOT_HANDSHAKING ) {
-      if(Clock.lastKnownForwardProgressingMillis() - startTime > setTimeout) {
-        throw new IOException("Timeout doing SSLHandshake!");
+  public ListenableFuture<SSLSession> doHandShake() throws IOException {
+    if(doneHandshake.compareAndSet(false, true)) {
+      handShakeStart = Clock.lastKnownForwardProgressingMillis(); 
+      ssle.beginHandshake();
+      if(ssle.getHandshakeStatus() == NEED_WRAP) {
+        writeForce(ByteBuffer.allocate(0));
       }
-
-      select.selectedKeys().clear();
-      if(hs == NEED_UNWRAP) {
-        channel.register(select, SelectionKey.OP_READ);
-        select.select(100);
-      } else if (hs == NEED_WRAP) {
-        channel.register(select, SelectionKey.OP_WRITE);
-        select.select(100);
-      }
-      channel.register(select, 0);
-      
-      if(hs == NEED_UNWRAP ) {
-        hs = doHandShakeRead(netDataBuffer, ePeerAppData, ssle, channel);
-        if(hs == NEED_TASK) {
-          runTasks();
-          hs = ssle.getHandshakeStatus();
-        }
-      }
-      if(hs ==  NEED_WRAP) {
-        hs = doHandShakeWrite(appDataBuffer, eNetworkData, ssle, channel);
-        if(hs == NEED_TASK) {
-          runTasks();
-          hs = ssle.getHandshakeStatus();
-        }
+      if(this.ce != null) {
+        ce.getThreadScheduler().schedule(new Runnable() {
+          @Override
+          public void run() {
+            if(!handshakeFuture.isDone()) {
+              handshakeFuture.setFailure(new TimeoutException("Timed out doing SSLHandshake!!!"));
+              close();
+            }
+          }}, setTimeout);
       }
     }
-    select.close();
-    tmpAppBuffer = appDataBuffer;
-    tmpAppBuffer.clear();
+    return handshakeFuture;
+  }
+  
+  @Override
+  protected void setThreadExecuter(SubmitterExecutorInterface sei) {
+    super.setThreadExecuter(sei);
+  }
+  
+  @Override
+  protected void setSocketExecuter(SocketExecuterBase ce) {
+    super.setSocketExecuter(ce);
+    if(doneHandshake.get() && !handshakeFuture.isDone()) {
+      ce.getThreadScheduler().schedule(new Runnable() {
+        @Override
+        public void run() {
+          if(!handshakeFuture.isDone()) {
+            handshakeFuture.setFailure(new TimeoutException("Timed out doing SSLHandshake!!!"));
+            close();
+          }
+        }}, setTimeout);
+    }
   }
   
   private void runTasks() {
@@ -223,23 +211,55 @@ public class SSLClient extends TCPClient implements Reader{
   
   @Override
   public void writeForce(ByteBuffer buffer) {
-    if (!this.isClosed() && buffer.hasRemaining()) {
-      synchronized(ssle) {
-        ByteBuffer oldBB = buffer.duplicate();
-        ByteBuffer newBB; 
-        ByteBuffer tmpBB;
-        while (oldBB.remaining() > 0) {
-          newBB = getAppWriteBuffer();
-          try {
-            tmpBB = newBB.duplicate();
-            //TODO: Is there a reason to check the return of wrap??
-            ssle.wrap(oldBB, newBB);
-            tmpBB.limit(newBB.position());
-            super.writeForce(tmpBB);
-          } catch(Exception e) {
-            break;
+    if (!this.isClosed()) {
+      if(this.doneHandshake.get()) {
+        synchronized(ssle) {
+          if(ssle.getHandshakeStatus() != NOT_HANDSHAKING && buffer.remaining() > 0) {
+            this.tmpWriteBuffers.add(buffer);
+            return;
           }
+          ByteBuffer oldBB = buffer.duplicate();
+          ByteBuffer newBB; 
+          ByteBuffer tmpBB;
+          while (ssle.getHandshakeStatus() == NEED_WRAP || oldBB.remaining() > 0) {
+            newBB = getAppWriteBuffer();
+            try {
+              tmpBB = newBB.duplicate();
+              SSLEngineResult res = ssle.wrap(oldBB, newBB);
+              tmpBB.limit(newBB.position());
+              //System.out.println(this+"WROTE:"+tmpBB);
+              super.writeForce(tmpBB);
+              if(res.getHandshakeStatus() == FINISHED) {
+                ByteBuffer localBB = null;
+                synchronized(tmpWriteBuffers) {
+                  if(tmpWriteBuffers.remaining() > 0) {
+                    localBB = (tmpWriteBuffers.pull(tmpWriteBuffers.remaining()));
+                  }
+                }
+                if(localBB != null && localBB.remaining() > 0) {
+                  oldBB = localBB;
+                }
+                if(!handshakeFuture.isDone()) {
+                  handshakeFuture.setResult(ssle.getSession());
+                }
+              }else {
+                while (ssle.getHandshakeStatus() == NEED_TASK) {
+                  runTasks();
+                }
+              }
+            } catch(Exception e) {
+              if(!handshakeFuture.isDone()) {
+                handshakeFuture.setFailure(e);
+                this.close();
+              }
+              break;
+            }
+          }
+
         }
+      } else {
+        System.out.println(this+"ONWRITE:NOSSL");
+        super.writeForce(buffer);
       }
     }
   }
@@ -258,39 +278,69 @@ public class SSLClient extends TCPClient implements Reader{
 
   @Override
   public void onRead(Client client) {
-    try {
-      ByteBuffer client_buffer = super.getRead();
-      while(client_buffer.hasRemaining()) {
-        if(client_buffer.remaining() > encryptedReadBuffer.remaining()) {
-          byte[] ba = new byte[encryptedReadBuffer.remaining()];
-          client_buffer.get(ba);
-          encryptedReadBuffer.put(ba);
-        } else {
-          encryptedReadBuffer.put(client_buffer);
-        }
-        while(encryptedReadBuffer.position() > 0) {
-          encryptedReadBuffer.flip();
-          ByteBuffer dbb = getDecryptedByteBuffer();
-          ByteBuffer newBB = dbb.duplicate();
-          @SuppressWarnings("unused")
-          SSLEngineResult res = ssle.unwrap(encryptedReadBuffer, dbb);
-          newBB.limit(dbb.position());
-          encryptedReadBuffer.compact();
-          if(newBB.hasRemaining()) {
-            if(sslReader != null) {
-              synchronized(decryptedReadList) {
-                decryptedReadList.add(newBB);
-              }
-              sslReader.onRead(this);
-            }
+    ByteBuffer client_buffer = super.getRead();
+    if(this.doneHandshake.get()) {
+      try {
+        while(client_buffer.hasRemaining()) {
+          if(client_buffer.remaining() > encryptedReadBuffer.remaining()) {
+            byte[] ba = new byte[encryptedReadBuffer.remaining()];
+            client_buffer.get(ba);
+            encryptedReadBuffer.put(ba);
           } else {
-            break;
+            encryptedReadBuffer.put(client_buffer);
+          }
+          while(encryptedReadBuffer.position() > 0) {
+            encryptedReadBuffer.flip();
+            ByteBuffer dbb = getDecryptedByteBuffer();
+            ByteBuffer newBB = dbb.duplicate();
+
+            SSLEngineResult res = ssle.unwrap(encryptedReadBuffer, dbb);
+            if(res.getHandshakeStatus() == FINISHED) {
+              ByteBuffer localBB = null;
+              synchronized(tmpWriteBuffers) {
+                if(tmpWriteBuffers.remaining() > 0) {
+                  localBB = (tmpWriteBuffers.pull(tmpWriteBuffers.remaining()));
+                }
+              }
+              if(localBB != null && localBB.remaining() > 0) {
+                writeForce(localBB);
+              }
+              if(!handshakeFuture.isDone()) {
+                handshakeFuture.setResult(ssle.getSession());
+              }
+            } else if (ssle.getHandshakeStatus() != NOT_HANDSHAKING){
+              while (ssle.getHandshakeStatus() == NEED_TASK) {
+                runTasks();
+              }
+              if(ssle.getHandshakeStatus() == NEED_WRAP) {
+                writeForce(ByteBuffer.allocate(0));
+              }
+            }
+            newBB.limit(dbb.position());
+            encryptedReadBuffer.compact();
+            if(newBB.hasRemaining()) {
+              if(sslReader != null) {
+                synchronized(decryptedReadList) {
+                  decryptedReadList.add(newBB);
+                }
+                sslReader.onRead(this);
+              }
+            } else if (res.getStatus() == Status.BUFFER_UNDERFLOW || encryptedReadBuffer.remaining() == 0 || (ssle.getHandshakeStatus() != NOT_HANDSHAKING & ssle.getHandshakeStatus() != NEED_UNWRAP)){
+              break;
+            }
           }
         }
+      } catch (SSLException e) {
+        if(!handshakeFuture.isDone()) {
+          handshakeFuture.setFailure(e);
+        }
+        ExceptionUtils.handleException(e);
+        this.close();
       }
-    } catch (SSLException e) {
-      ExceptionUtils.handleException(e);
-      this.close();
+    } else {
+      System.out.println(this+"ONREAD:NOSSL");
+      decryptedReadList.add(client_buffer);
+      sslReader.onRead(this);
     }
   }
   

--- a/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
+++ b/src/main/java/org/threadly/litesockets/tcp/SSLClient.java
@@ -2,21 +2,16 @@ package org.threadly.litesockets.tcp;
 
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.FINISHED;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_TASK;
-import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_WRAP;
-import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.SSLContext;
@@ -25,7 +20,6 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -34,10 +28,9 @@ import org.threadly.concurrent.SubmitterExecutorInterface;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.SettableListenableFuture;
 import org.threadly.litesockets.Client;
-import org.threadly.litesockets.SocketExecuterBase;
 import org.threadly.litesockets.Client.Reader;
+import org.threadly.litesockets.SocketExecuterBase;
 import org.threadly.litesockets.utils.MergedByteBuffers;
-import org.threadly.util.Clock;
 import org.threadly.util.ExceptionUtils;
 
 /**
@@ -48,28 +41,8 @@ import org.threadly.util.ExceptionUtils;
  *
  */
 public class SSLClient extends TCPClient implements Reader{
-  private static final String SSL_HANDSHAKE_ERROR = "Problem doing SSL Handshake";
   private static final TrustManager[] OPEN_TRUST_MANAGER = new TrustManager [] {new GenericTrustManager() };
   private static final SSLContext OPEN_SSL_CTX; 
-
-  private final MergedByteBuffers decryptedReadList = new MergedByteBuffers();
-  public final MergedByteBuffers tmpWriteBuffers = new MergedByteBuffers();
-  public final SSLEngine ssle;
-  private final SettableListenableFuture<SSLSession> handshakeFuture = new SettableListenableFuture<SSLSession>();
-  private final AtomicBoolean startedHandshake = new AtomicBoolean(false);
-  private final AtomicBoolean finishedHandshake = new AtomicBoolean(false);
-
-
-  private ByteBuffer writeBuffer;
-
-  private final ByteBuffer encryptedReadBuffer;
-  private ByteBuffer decryptedReadBuffer;
-
-  private volatile Reader sslReader; 
-
-  public static void disableSNI() {
-    System.setProperty ("jsse.enableSNIExtension", "false");
-  }
 
   static {
     try {
@@ -81,20 +54,79 @@ public class SSLClient extends TCPClient implements Reader{
     } catch (KeyManagementException e) {
       throw new RuntimeException(e);
     }
-  }
+  }  
+  
+  private final MergedByteBuffers decryptedReadList = new MergedByteBuffers();
+  private final MergedByteBuffers tmpWriteBuffers = new MergedByteBuffers();
+  private final SSLEngine ssle;
+  private final SettableListenableFuture<SSLSession> handshakeFuture = new SettableListenableFuture<SSLSession>();
+  private final AtomicBoolean startedHandshake = new AtomicBoolean(false);
+  private final AtomicBoolean finishedHandshake = new AtomicBoolean(false);
+  private final ByteBuffer encryptedReadBuffer;
+  
+  private volatile Reader sslReader;
+  private ByteBuffer writeBuffer;
+  private ByteBuffer decryptedReadBuffer; 
 
+  /**
+   * <p>This is a simple SSLConstructor.  It uses the default socket timeout, and very insecure cert
+   * checking.  This setup to generally connect to any server, and does not validate anything.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param host The host or IP to connect to.
+   * @param port The port on the host to connect to.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(String host, int port) throws IOException {
     this(host, port, OPEN_SSL_CTX.createSSLEngine(host, port));
   }
 
+  /**
+   * <p>This simple SSLConstructor.  It allows you to specify the SSLEngine to use to allow you to
+   * validate the servers certs with the parameters you decide.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param host The host or IP to connect to.
+   * @param port The port on the host to connect to.
+   * @param ssle The SSLEngine to use for the connection.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(String host, int port, SSLEngine ssle) throws IOException {
     this(host, port, ssle, TCPClient.DEFAULT_SOCKET_TIMEOUT);
   }
 
+  /**
+   * <p>This constructor allows you to specify the SSLEngine to use to
+   * validate the server certs with the parameters you decide.  
+   * It also allows you to set the timeout values.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param host The host or IP to connect to.
+   * @param port The port on the host to connect to.
+   * @param ssle The SSLEngine to use for the connection.
+   * @param timeout This is the connection timeout.  It is used for the actual connection timeout and separately for the SSLHandshake.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(String host, int port, SSLEngine ssle, int timeout) throws IOException {
     this(host, port, ssle, TCPClient.DEFAULT_SOCKET_TIMEOUT, true);
   }
 
+  /**
+   * <p>This constructor allows you to specify the SSLEngine to use to allow you to
+   * validate the servers certs with the parameters you decide.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param host The host or IP to connect to.
+   * @param port The port on the host to connect to.
+   * @param ssle The SSLEngine to use for the connection.
+   * @param timeout This is the connection timeout.  It is used for the actual connection timeout and separately for the SSLHandshake.
+   * @param doHandshake This allows you to delay the handshake till a later negotiated time.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(String host, int port, SSLEngine ssle, int timeout, boolean doHandshake) throws IOException {
     super(host, port, timeout);
     this.ssle = ssle;
@@ -106,10 +138,33 @@ public class SSLClient extends TCPClient implements Reader{
     encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize()+50);
   }
 
+  /**
+   * <p>This constructor is for already existing connections. It also allows you to specify the SSLEngine 
+   * to use to allow you to validate the servers certs with the parameters you decide.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param client The SocketChannel to use for the SSLClient.
+   * @param ssle The SSLEngine to use for the connection.
+   * @param clientSSL Set this to true if this is a client side connection, false if its server side.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(SocketChannel client, SSLEngine ssle, boolean clientSSL) throws IOException {
     this(client, ssle, clientSSL, true);
   }
 
+  /**
+   * <p>This constructor is for already existing connections. It also allows you to specify the SSLEngine 
+   * to use to allow you to validate the servers certs with the parameters you decide.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param client The SocketChannel to use for the SSLClient.
+   * @param ssle The SSLEngine to use for the connection.
+   * @param clientSSL Set this to true if this is a client side connection, false if its server side.
+   * @param doHandshake This allows you to delay the handshake till a later negotiated time.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(SocketChannel client, SSLEngine ssle, boolean clientSSL, boolean doHandshake) throws IOException {
     super(client);
     this.ssle = ssle;
@@ -121,6 +176,18 @@ public class SSLClient extends TCPClient implements Reader{
     encryptedReadBuffer = ByteBuffer.allocate(ssle.getSession().getPacketBufferSize()+50);
   }
 
+  /**
+   * <p>This constructor is for already existing connections. It also allows you to specify the SSLEngine 
+   * to use to allow you to validate the servers certs with the parameters you decide.</p>
+   * 
+   * <p>Because we are making the connection this is always a "ClientSide" connection.</p>
+   *  
+   * @param client The TCPClient to use for the SSLClient.
+   * @param ssle The SSLEngine to use for the connection.
+   * @param clientSSL Set this to true if this is a client side connection, false if its server side.
+   * @param doHandshake This allows you to delay the handshake till a later negotiated time.
+   * @throws IOException An IOException is thrown if there is a failure to connect for any reason.
+   */
   public SSLClient(TCPClient client, SSLEngine ssle, boolean clientSSL, boolean doHandshake) throws IOException {
     super(client.getChannel());
     if(client.getReadBufferSize() > 0 || client.getWriteBufferSize() > 0) {
@@ -148,6 +215,10 @@ public class SSLClient extends TCPClient implements Reader{
     return decryptedReadBuffer;
   }
 
+  /**
+   * This lets you know if the connection is currently encrypted or not.
+   * @return true if the connection is encrypted false if not.
+   */
   public boolean isEncrypted() {
     if(startedHandshake.get() && ssle.getSession().getProtocol().equals("NONE")) {
       return false;
@@ -155,9 +226,23 @@ public class SSLClient extends TCPClient implements Reader{
     return true;
   }
 
-  public ListenableFuture<SSLSession> doHandShake() throws IOException {
+  /**
+   * <p>If doHandshake was set to false in the constructor you can start the handshake by calling this method.
+   * The client will not start the handshake till its added to a SocketExecuter.  The future allows you to know
+   * when the handshake has finished if if there was an error.  While the handshake is processing all writes to the 
+   * socket will queue.</p>
+   * 
+   * 
+   * @return A listenable Future.  If a result was given it succeeded, if there is an error it failed.  The connection is closed on failures.
+   * @throws IOException
+   */
+  public ListenableFuture<SSLSession> doHandShake() {
     if(startedHandshake.compareAndSet(false, true)) {
-      ssle.beginHandshake();
+      try {
+        ssle.beginHandshake();
+      } catch (SSLException e) {
+        this.handshakeFuture.setFailure(e);
+      }
       if(ssle.getHandshakeStatus() == NEED_WRAP) {
         writeForce(ByteBuffer.allocate(0));
       }
@@ -406,5 +491,7 @@ public class SSLClient extends TCPClient implements Reader{
    * The default is whatever the VM is started with you can disable it by running this method.
    * 
    */
-
+  public static void disableSNI() {
+    System.setProperty ("jsse.enableSNIExtension", "false");
+  }
 }

--- a/src/main/java/org/threadly/litesockets/tcp/SSLServer.java
+++ b/src/main/java/org/threadly/litesockets/tcp/SSLServer.java
@@ -27,12 +27,12 @@ public class SSLServer extends TCPServer {
     int port = ((SocketChannel)c).socket().getPort();
     final SSLEngine ssle = sctx.createSSLEngine(remote, port);
     try {
-      final SSLClient client = new SSLClient((SocketChannel)c, ssle, false);
+      final SSLClient client = new SSLClient((SocketChannel)c, ssle, false, false);
       if(this.getClientAcceptor() != null) {
         getClientAcceptor().accept(client);
       }
     } catch (IOException e1) {
-      
+      e1.printStackTrace();
     }
   }
 

--- a/src/main/java/org/threadly/litesockets/tcp/SSLServer.java
+++ b/src/main/java/org/threadly/litesockets/tcp/SSLServer.java
@@ -25,14 +25,15 @@ public class SSLServer extends TCPServer {
   public void accept(final SelectableChannel c) {
     String remote = ((SocketChannel)c).socket().getRemoteSocketAddress().toString();
     int port = ((SocketChannel)c).socket().getPort();
-    final SSLEngine ssle = sctx.createSSLEngine(remote, port);
-    try {
-      final SSLClient client = new SSLClient((SocketChannel)c, ssle, false, false);
-      if(this.getClientAcceptor() != null) {
+    ClientAcceptor ca = getClientAcceptor();
+    if(ca != null) {
+      final SSLEngine ssle = sctx.createSSLEngine(remote, port);
+      try {
+        final SSLClient client = new SSLClient((SocketChannel)c, ssle, false, false);
         getClientAcceptor().accept(client);
+      } catch (IOException e1) {
+        e1.printStackTrace();
       }
-    } catch (IOException e1) {
-      e1.printStackTrace();
     }
   }
 

--- a/src/test/java/org/threadly/litesockets/tcp/FakeTCPServerClient.java
+++ b/src/test/java/org/threadly/litesockets/tcp/FakeTCPServerClient.java
@@ -1,6 +1,5 @@
 package org.threadly.litesockets.tcp;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,7 +11,6 @@ import org.threadly.litesockets.Server;
 import org.threadly.litesockets.Server.ClientAcceptor;
 import org.threadly.litesockets.Server.ServerCloser;
 import org.threadly.litesockets.SocketExecuterBase;
-import org.threadly.litesockets.ThreadedSocketExecuter;
 import org.threadly.litesockets.utils.MergedByteBuffers;
 
 public class FakeTCPServerClient implements Reader, Closer, ClientAcceptor, ServerCloser{
@@ -50,11 +48,7 @@ public class FakeTCPServerClient implements Reader, Closer, ClientAcceptor, Serv
     client = (TCPClient)sc;
     if(sc instanceof SSLClient) {
       SSLClient sslc = (SSLClient)sc;
-      try {
-        sslc.doHandShake();
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
+      sslc.doHandShake();
     }
     addTCPClient(client);
   }

--- a/src/test/java/org/threadly/litesockets/tcp/FakeTCPServerClient.java
+++ b/src/test/java/org/threadly/litesockets/tcp/FakeTCPServerClient.java
@@ -1,5 +1,6 @@
 package org.threadly.litesockets.tcp;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,6 +48,14 @@ public class FakeTCPServerClient implements Reader, Closer, ClientAcceptor, Serv
   public void accept(Client sc) {
     TCPClient client;
     client = (TCPClient)sc;
+    if(sc instanceof SSLClient) {
+      SSLClient sslc = (SSLClient)sc;
+      try {
+        sslc.doHandShake();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
     addTCPClient(client);
   }
   
@@ -58,9 +67,9 @@ public class FakeTCPServerClient implements Reader, Closer, ClientAcceptor, Serv
   }
   
   public void addTCPClient(TCPClient client) {
-    map.putIfAbsent(client, new MergedByteBuffers());
+    MergedByteBuffers mbb = map.putIfAbsent(client, new MergedByteBuffers());
     clients.add(client);
-    System.out.println("Accepted new Client!:"+map.size()+":"+client);
+    System.out.println("Accepted new Client!:"+map.size()+":"+client+":"+mbb);
     client.setReader(this);
     client.setCloser(this);
     se.addClient(client);

--- a/src/test/java/org/threadly/litesockets/tcp/NoThreadTCPTests.java
+++ b/src/test/java/org/threadly/litesockets/tcp/NoThreadTCPTests.java
@@ -12,6 +12,7 @@ import org.threadly.litesockets.ThreadedSocketExecuter;
 public class NoThreadTCPTests extends TCPTests {
   NoThreadSocketExecuter ntSE;
   SingleThreadScheduler STS;
+  volatile boolean keepRunning = true;
   
   @Before
   public void start() throws IOException {
@@ -23,7 +24,7 @@ public class NoThreadTCPTests extends TCPTests {
     STS.execute(new Runnable() {
       @Override
       public void run() {
-        while(ntSE.isRunning()) {
+        while(ntSE.isRunning() && keepRunning) {
           ntSE.select(1000);
         }
       }});
@@ -36,7 +37,14 @@ public class NoThreadTCPTests extends TCPTests {
   
   @Override
   @After
-  public void stop() {
+  public void stop(){
+    keepRunning = false;
+    ntSE.wakeup();
+    ntSE.wakeup();
+    ntSE.wakeup();
+    ntSE.wakeup();
+    
+    
     super.stop();
     STS.shutdownNow();
   }

--- a/src/test/java/org/threadly/litesockets/tcp/SSLTests.java
+++ b/src/test/java/org/threadly/litesockets/tcp/SSLTests.java
@@ -13,6 +13,8 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -25,9 +27,11 @@ import org.threadly.concurrent.PriorityScheduler;
 import org.threadly.litesockets.Client;
 import org.threadly.litesockets.Client.Reader;
 import org.threadly.litesockets.Server;
+import org.threadly.litesockets.Server.ClientAcceptor;
 import org.threadly.litesockets.SocketExecuterBase;
 import org.threadly.litesockets.ThreadedSocketExecuter;
 import org.threadly.litesockets.tcp.SSLClient.GenericTrustManager;
+import org.threadly.litesockets.utils.MergedByteBuffers;
 import org.threadly.test.concurrent.TestCondition;
 
 public class SSLTests {
@@ -54,7 +58,8 @@ public class SSLTests {
     KS.load(ksf, "password".toCharArray());
     kmf = KeyManagerFactory.getInstance("SunX509");
     kmf.init(KS, "password".toCharArray());
-    sslCtx = SSLContext.getInstance("TLS");
+    //sslCtx = SSLContext.getInstance("TLS");
+    sslCtx = SSLContext.getInstance("SSL");
     sslCtx.init(kmf.getKeyManagers(), myTMs, null);
     serverFC = new FakeTCPServerClient(SE);
   }
@@ -70,11 +75,14 @@ public class SSLTests {
     }
     SE.stop();
     PS.shutdownNow();
+    serverFC = new FakeTCPServerClient(SE);
   }
+ 
   
   @Test
-  public void simpleWriteTest() throws IOException {
+  public void simpleWriteTest() throws IOException, InterruptedException {
     long start = System.currentTimeMillis();
+    port = Utils.findTCPPort();
     SSLServer server = new SSLServer("localhost", port, sslCtx);
     serverFC.addTCPServer(server);
     
@@ -97,7 +105,7 @@ public class SSLTests {
         return serverFC.clients.size() == 2;
       }
     }.blockTillTrue(5000);
-    
+    Thread.sleep(100);
     sclient.writeForce(TCPTests.SMALL_TEXT_BUFFER.duplicate());
     
     new TestCondition(){
@@ -109,19 +117,21 @@ public class SSLTests {
     
     String st = serverFC.map.get(client).getAsString(serverFC.map.get(client).remaining());
     assertEquals(TCPTests.SMALL_TEXT, st);
-    
   }
 
   @Test
-  public void sslClientTimeout() throws IOException {
+  public void sslClientTimeout() throws IOException, InterruptedException, ExecutionException {
     TCPServer server = new TCPServer("localhost", port);
     serverFC.addTCPServer(server);
     long start = System.currentTimeMillis();
     try {
-      final SSLClient client = new SSLClient("localhost", port, this.sslCtx.createSSLEngine("localhost", port), 200);
+      final SSLClient client = new SSLClient("localhost", port, this.sslCtx.createSSLEngine("localhost", port), 200, false);
+      SE.addClient(client);
+      client.doHandShake().get();
       fail();
-    } catch(IOException e) {
-      assertTrue(System.currentTimeMillis()-start > 200);
+    } catch(ExecutionException e) {
+      e.printStackTrace();
+      assertTrue(System.currentTimeMillis()-start >= 200);
       System.out.println(System.currentTimeMillis()-start );
     }
     server.close();
@@ -143,7 +153,7 @@ public class SSLTests {
         return serverFC.clients.size() == 1;
       }
     }.blockTillTrue(5000);
-    SSLClient sclient = (SSLClient) serverFC.clients.get(0);
+    final SSLClient sclient = (SSLClient) serverFC.clients.get(0);
     
     serverFC.addTCPClient(client);
 
@@ -162,9 +172,11 @@ public class SSLTests {
     new TestCondition(){
       @Override
       public boolean get() {
+        System.out.println(serverFC.map.get(client).remaining()+":"+(TCPTests.LARGE_TEXT_BUFFER.remaining()*3)+":"+sclient.tmpWriteBuffers.remaining());
+        System.out.println();
         return serverFC.map.get(client).remaining() == TCPTests.LARGE_TEXT_BUFFER.remaining()*3;
       }
-    }.blockTillTrue(5000);
+    }.blockTillTrue(5000, 500);
     
     String st = serverFC.map.get(client).getAsString(TCPTests.LARGE_TEXT_BUFFER.remaining());
     assertEquals(TCPTests.LARGE_TEXT, st);
@@ -176,41 +188,62 @@ public class SSLTests {
   }
   
   
+  //@Test
+  public void loop() throws IOException, InterruptedException {
+    for(int i=0; i<100; i++) {
+      useTCPClient();
+      serverFC = new FakeTCPServerClient(SE);
+    }
+  }
+  
+  
   @Test
-  public void useTCPClient() throws IOException {
+  public void useTCPClient() throws IOException, InterruptedException {
+    System.out.println("-----------------------------------------------------");
     long start = System.currentTimeMillis();
+    port = Utils.findTCPPort();
     SSLServer server = new SSLServer("localhost", port, sslCtx);
     serverFC.addTCPServer(server);
+    //System.out.println(serverFC);
     
     final TCPClient tcp_client = new TCPClient("localhost", port);
-    System.out.println(System.currentTimeMillis()-start);
-    final SSLClient client = new SSLClient(tcp_client, this.sslCtx.createSSLEngine("localhost", port), true);
-    
+    //System.out.println(System.currentTimeMillis()-start);
+    final SSLClient client = new SSLClient(tcp_client, this.sslCtx.createSSLEngine("localhost", port), true, true);
+    //System.out.println(serverFC);
     new TestCondition(){
       @Override
       public boolean get() {
         return serverFC.clients.size() == 1;
       }
     }.blockTillTrue(5000);
-    SSLClient sclient = (SSLClient) serverFC.clients.get(0);
-    
-    serverFC.addTCPClient(client);
+    final SSLClient sclient = (SSLClient) serverFC.clients.get(0);
+
 
     new TestCondition(){
       @Override
       public boolean get() {
-        return serverFC.clients.size() == 2;
+        return serverFC.clients.size() == 1;
       }
     }.blockTillTrue(5000);
-    
+    //Thread.sleep(1000);
+    //System.out.println("Writting");
     sclient.writeForce(TCPTests.SMALL_TEXT_BUFFER.duplicate());
-    
+    serverFC.addTCPClient(client);
+    //System.out.println("Wrote");
     new TestCondition(){
       @Override
       public boolean get() {
+        /*
+        System.out.println(serverFC);
+        System.out.println(serverFC.map.get(client).remaining());
+        System.out.println(serverFC.clients.size());
+        System.out.println(client.isEncrypted());
+        System.out.println(sclient.isEncrypted());
+        */
         return serverFC.map.get(client).remaining() > 2;
+        
       }
-    }.blockTillTrue(5000);
+    }.blockTillTrue(5000, 100);
     
     String st = serverFC.map.get(client).getAsString(serverFC.map.get(client).remaining());
     assertEquals(TCPTests.SMALL_TEXT, st);
@@ -251,6 +284,106 @@ public class SSLTests {
       }
     }.blockTillTrue(5000);
     
-    final SSLClient client = new SSLClient(tcp_client, this.sslCtx.createSSLEngine("localhost", port), true);
+    final SSLClient client = new SSLClient(tcp_client, this.sslCtx.createSSLEngine("localhost", port), true, true);
+  }
+  
+  @Test
+  public void doLateSSLhandshake() throws IOException, InterruptedException {
+    SSLServer server = new SSLServer("localhost", port, sslCtx);
+    final AtomicReference<SSLClient> servers_client = new AtomicReference<SSLClient>();
+    final AtomicReference<String> serversEncryptedString = new AtomicReference<String>();
+    final AtomicReference<String> clientsEncryptedString = new AtomicReference<String>();
+    
+    server.setClientAcceptor(new ClientAcceptor() {
+      @Override
+      public void accept(Client c) {
+        final SSLClient sslc = (SSLClient) c;
+        servers_client.set(sslc);
+        sslc.setReader(new Reader() {
+          MergedByteBuffers mbb = new MergedByteBuffers();
+          boolean didSSL = false;
+          @Override
+          public void onRead(Client client) {
+            mbb.add(client.getRead());
+            if(!didSSL && mbb.remaining() >= 6) {
+              String tmp = mbb.getAsString(6);
+              if(tmp.equals("DO_SSL")) {
+                didSSL = true;
+                sslc.writeForce(ByteBuffer.wrap("DO_SSL".getBytes()));
+                try {
+                  sslc.doHandShake();
+                } catch (IOException e) {
+                  e.printStackTrace();
+                }
+              }
+            } else {
+              if(mbb.remaining() >= 19) {
+                String tmp = mbb.getAsString(19);
+                serversEncryptedString.set(tmp);
+                client.writeForce(ByteBuffer.wrap("THIS WAS ENCRYPTED!".getBytes()));
+              }
+            }
+          }});
+        SE.addClient(sslc);
+      }});
+    SE.addServer(server);
+    
+    final SSLClient sslclient = new SSLClient("localhost", port, this.sslCtx.createSSLEngine("localhost", port), SSLClient.DEFAULT_SOCKET_TIMEOUT, false);
+    sslclient.setReader(new Reader() {
+      MergedByteBuffers mbb = new MergedByteBuffers();
+      boolean didSSL = false;
+      @Override
+      public void onRead(Client client) {
+        mbb.add(client.getRead());
+        if(!didSSL && mbb.remaining() >= 6) {
+          String tmp = mbb.getAsString(6);
+          if(tmp.equals("DO_SSL")) {
+            didSSL = true;
+            try {
+              sslclient.doHandShake();
+              sslclient.writeForce(ByteBuffer.wrap("THIS WAS ENCRYPTED!".getBytes()));     
+            } catch (IOException e) {
+              e.printStackTrace();
+            }
+          }
+        } else {
+          if(mbb.remaining() >= 19) {
+            String tmp = mbb.getAsString(19);
+            clientsEncryptedString.set(tmp);
+          }
+        }
+      }});
+    SE.addClient(sslclient);
+    //System.out.println("WRITE!!");
+    sslclient.writeForce(ByteBuffer.wrap("DO_SSL".getBytes()));
+    new TestCondition(){
+      @Override
+      public boolean get() {
+        return clientsEncryptedString.get() != null && serversEncryptedString.get() != null;
+      }
+    }.blockTillTrue(5000);
+    assertEquals(clientsEncryptedString.get(), serversEncryptedString.get());
+  }
+  
+  //@Test
+  public void test() throws IOException, InterruptedException {
+    final SSLClient sslclient = new SSLClient("google.com", 443, this.sslCtx.createSSLEngine("localhost", port), SSLClient.DEFAULT_SOCKET_TIMEOUT);
+    sslclient.setReader(new Reader() {
+      MergedByteBuffers mbb = new MergedByteBuffers();
+      @Override
+      public void onRead(Client client) {
+        mbb.add(client.getRead());
+        System.out.println("OUT:"+mbb.getAsString(mbb.remaining()));
+      }});
+    SE.addClient(sslclient);
+    
+    sslclient.doHandShake();
+    /*while(true) {
+      Thread.sleep(1000);
+      System.out.println(sslclient.ssle.getHandshakeStatus());
+    }*/
+    Thread.sleep(1000);
+    sslclient.writeForce(ByteBuffer.wrap(text.getBytes()));
+    Thread.sleep(5000);
   }
 }

--- a/src/test/java/org/threadly/litesockets/tcp/SSLTests.java
+++ b/src/test/java/org/threadly/litesockets/tcp/SSLTests.java
@@ -106,8 +106,9 @@ public class SSLTests {
       }
     }.blockTillTrue(5000);
     Thread.sleep(100);
+    System.out.println("Write");
     sclient.writeForce(TCPTests.SMALL_TEXT_BUFFER.duplicate());
-    
+    System.out.println("Write Done");
     new TestCondition(){
       @Override
       public boolean get() {
@@ -172,8 +173,8 @@ public class SSLTests {
     new TestCondition(){
       @Override
       public boolean get() {
-        System.out.println(serverFC.map.get(client).remaining()+":"+(TCPTests.LARGE_TEXT_BUFFER.remaining()*3)+":"+sclient.tmpWriteBuffers.remaining());
-        System.out.println();
+        //System.out.println(serverFC.map.get(client).remaining()+":"+(TCPTests.LARGE_TEXT_BUFFER.remaining()*3));
+        //System.out.println();
         return serverFC.map.get(client).remaining() == TCPTests.LARGE_TEXT_BUFFER.remaining()*3;
       }
     }.blockTillTrue(5000, 500);
@@ -225,7 +226,6 @@ public class SSLTests {
         return serverFC.clients.size() == 1;
       }
     }.blockTillTrue(5000);
-    //Thread.sleep(1000);
     //System.out.println("Writting");
     sclient.writeForce(TCPTests.SMALL_TEXT_BUFFER.duplicate());
     serverFC.addTCPClient(client);


### PR DESCRIPTION
The main change to this was to allow an SSLClient to not have to start as an encrypted stream.  It evolved a lot while it was worked on, and now it also causes the ssl negotiation to happen on the SocketExecuter and not on the thread calling the handshake.

I also removed the Reader interface from the SSL client.  This was done because the any class extending the SSLClient could have problems if it also implemented the Reader interface as it would call the extending classes onRead method.  SSLClient now has an inner class for the Reader.