### PR TITLE
Possible updates to reduce build code duplication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,35 +1,5 @@
-apply plugin: 'java'
-apply plugin: 'checkstyle'
-apply plugin: 'maven'
-apply plugin: 'signing'
+apply from: 'build.shared'
 apply plugin: 'jacoco'
-
-repositories {
-  mavenCentral()
-}
-
-project.archivesBaseName='litesockets'
-
-plugins.withType(JavaPlugin) {
-  checkstyle.sourceSets = [sourceSets.main]
-}
-
-
-dependencies {
-  testCompile group: 'junit', name: 'junit', version: '4.12'
-
-  compile (
-    "org.threadly:threadly:$threadlyVersion"
-  )
-}
-
-compileJava {
-  options.compilerArgs << "-Xlint:all" << "-Werror"
-}
-
-compileTestJava {
-  options.compilerArgs << "-Xlint:all" << "-Xlint:-deprecation" << "-Werror"
-}
 
 test {
   jacoco {
@@ -37,7 +7,6 @@ test {
     destinationFile = file("$buildDir/reports/jacoco/test.exec")
   }
 }
-
 
 build.dependsOn("jacocoTestReport");
 
@@ -60,34 +29,4 @@ jacocoTestReport {
     println "html - $buildDir/reports/jacoco/html/index.html"
     println "xml  - $buildDir/reports/jacoco/jacoco.xml"
   }
-}
-
-
-jar {
-  manifest {
-    attributes 'Implementation-Title': 'litesockets', 'Implementation-Version': version
-  }
-  baseName = 'litesockets'
-}
-
-
-javadoc {
-  source = sourceSets.main.allJava
-  options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PUBLIC
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
-  from 'build/docs/javadoc'
-}
-
-task sourcesJar(type: Jar) {
-  from sourceSets.main.allSource
-  classifier = 'sources'
-}
-
-artifacts {
-  archives jar
-  archives javadocJar
-  archives sourcesJar
 }

--- a/build.shared
+++ b/build.shared
@@ -1,0 +1,62 @@
+apply plugin: 'java'
+apply plugin: 'checkstyle'
+
+repositories {
+  mavenCentral()
+}
+
+project.archivesBaseName='litesockets'
+
+dependencies {
+  testCompile group: 'junit', name: 'junit', version: '4.12'
+
+  compile (
+    "org.threadly:threadly:$threadlyVersion"
+  )
+}
+
+compileJava {
+  options.compilerArgs << "-Xlint:all" << "-Werror"
+}
+
+compileTestJava {
+  options.compilerArgs << "-Xlint:all" << "-Xlint:-deprecation" << "-Werror"
+}
+
+plugins.withType(JavaPlugin) {
+  checkstyle.sourceSets = [sourceSets.main]
+}
+
+test {
+  getReports().getJunitXml().setDestination(file("${buildDir}/reports/tests/xml"))
+  getReports().getHtml().setDestination(file("${buildDir}/reports/tests/html"))
+  setBinResultsDir(file("${buildDir}/reports/tests/bin"))
+}
+
+jar {
+  manifest {
+    attributes 'Implementation-Title': 'litesockets', 'Implementation-Version': version
+  }
+  baseName = 'litesockets'
+}
+
+javadoc {
+  source = sourceSets.main.allJava
+  options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PUBLIC
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  from 'build/docs/javadoc'
+}
+
+task sourcesJar(type: Jar) {
+  from sourceSets.main.allSource
+  classifier = 'sources'
+}
+
+artifacts {
+  archives jar
+  archives javadocJar
+  archives sourcesJar
+}

--- a/build.upload
+++ b/build.upload
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply from: 'build.shared'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'checkstyle'
@@ -6,23 +6,7 @@ apply plugin: 'checkstyle'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-repositories {
-  mavenCentral()
-}
-
-project.archivesBaseName='litesockets'
-
-dependencies {
-  testCompile group: 'junit', name: 'junit', version: '4.12'
-
-  compile (
-    "org.threadly:threadly:$threadlyVersion"
-  )
-}
-
 compileJava {
-  options.compilerArgs << "-Xlint:all" << "-Xlint:-deprecation" << "-Werror"
-  
   String[] java6Paths = new String[5]
   java6Paths[0] = "/usr/lib/jvm/java-6-openjdk-amd64/jre/lib/rt.jar"
   java6Paths[1] = "/usr/lib/jvm/java-6-openjdk/jre/lib/rt.jar"
@@ -58,38 +42,6 @@ compileTestJava {
       break
     }
   }
-}
-
-test {
-  getReports().getJunitXml().setDestination(file("$buildDir/test-results/xml"))
-}
-
-jar {
-  manifest {
-    attributes 'Implementation-Title': 'litesockets', 'Implementation-Version': version
-  }
-  baseName = 'litesockets'
-}
-
-javadoc {
-  source = sourceSets.main.allJava
-  options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PUBLIC
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
-  from 'build/docs/javadoc'
-}
-
-task sourcesJar(type: Jar) {
-  from sourceSets.main.allSource
-  classifier = 'sources'
-}
-
-artifacts {
-  archives jar
-  archives javadocJar
-  archives sourcesJar
 }
 
 signing {


### PR DESCRIPTION
I wanted to do these changes at the same time as switching to jacoco.  I did the same thing in threadly, but this reduces the duplication between the build files and hopefully makes things more managable.

let me know your thoughts, this is by no means required.  I will look at your other PR closer once we either merge or decline this one.