### PR TITLE
Ssl transition fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 3.0.0
+version = 3.0.1-SNAPSHOT
 threadlyVersion = 4.4.0

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -45,8 +45,9 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
    * manually.
    */
   public void wakeup() {
-    checkRunning();
-    commonSelector.wakeup();
+    if(commonSelector != null && commonSelector.isOpen()) {
+      commonSelector.wakeup();
+    }
   }
 
   @Override

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -210,12 +210,10 @@ public class TCPClient extends Client {
       final SettableListenableFuture<Long> slf = new SettableListenableFuture<Long>(false);
       if(sslProcessor != null && sslProcessor.handShakeStarted()) {
         writeBuffers.add(sslProcessor.encrypt(bb));
-        writeFutures.add(new Pair<Long, SettableListenableFuture<Long>>(writeBuffers.getTotalConsumedBytes()+writeBuffers.remaining(), slf));
       } else {
         writeBuffers.add(bb);
-        writeFutures.add(new Pair<Long, SettableListenableFuture<Long>>(writeBuffers.getTotalConsumedBytes()+writeBuffers.remaining(), slf));
       }
-      
+      writeFutures.add(new Pair<Long, SettableListenableFuture<Long>>(writeBuffers.getTotalConsumedBytes()+writeBuffers.remaining(), slf));
       if(needNotify && se != null && channel.isConnected()) {
         se.setClientOperations(this);
       }

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -210,10 +210,12 @@ public class TCPClient extends Client {
       final SettableListenableFuture<Long> slf = new SettableListenableFuture<Long>(false);
       if(sslProcessor != null && sslProcessor.handShakeStarted()) {
         writeBuffers.add(sslProcessor.encrypt(bb));
+        writeFutures.add(new Pair<Long, SettableListenableFuture<Long>>(writeBuffers.getTotalConsumedBytes()+writeBuffers.remaining(), slf));
       } else {
         writeBuffers.add(bb);
+        writeFutures.add(new Pair<Long, SettableListenableFuture<Long>>(writeBuffers.getTotalConsumedBytes()+writeBuffers.remaining(), slf));
       }
-      this.writeFutures.add(new Pair<Long, SettableListenableFuture<Long>>(writeBuffers.getTotalConsumedBytes()+writeBuffers.remaining(), slf));
+      
       if(needNotify && se != null && channel.isConnected()) {
         se.setClientOperations(this);
       }

--- a/src/main/java/org/threadly/litesockets/utils/MergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/utils/MergedByteBuffers.java
@@ -47,7 +47,7 @@ public class MergedByteBuffers {
    */
   public void add(final ByteBuffer buffer) {
     if(buffer.hasRemaining()) {
-      ByteBuffer bb = buffer.duplicate();
+      ByteBuffer bb = buffer.slice();
       if(this.markReadOnly) {
         availableBuffers.add(bb.asReadOnlyBuffer());
       } else {

--- a/src/main/java/org/threadly/litesockets/utils/TransactionalByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/utils/TransactionalByteBuffers.java
@@ -163,12 +163,6 @@ public class TransactionalByteBuffers extends MergedByteBuffers {
       super.discard(size);
     }
   }
-  
-  @Override
-  public String getAsString(final int size) {
-    return super.getAsString(size);
-  }
-
 
   @Override
   protected ByteBuffer removeFirstBuffer() {

--- a/src/test/java/org/threadly/litesockets/JavaUtilsSETest.java
+++ b/src/test/java/org/threadly/litesockets/JavaUtilsSETest.java
@@ -5,7 +5,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.threadly.concurrent.PriorityScheduler;
 import org.threadly.litesockets.tcp.Utils;
 

--- a/src/test/java/org/threadly/litesockets/ServerExecuterTests.java
+++ b/src/test/java/org/threadly/litesockets/ServerExecuterTests.java
@@ -50,9 +50,7 @@ public class ServerExecuterTests {
     final int clientCount = 50;
     TCPServer server = SE.createTCPServer("localhost", port);
     final FakeTCPServerClient serverFC = new FakeTCPServerClient(SE);
-    server.setClientAcceptor(serverFC);
-    server.addCloseListener(serverFC);
-    server.start();
+    serverFC.addTCPServer(server);
     final ArrayList<TCPClient> clients = new  ArrayList<TCPClient>(clientCount);
     final ArrayList<TCPServer> servers = new  ArrayList<TCPServer>(clientCount);
     final ArrayList<FakeTCPServerClient> FCclients = new  ArrayList<FakeTCPServerClient>(clientCount);
@@ -64,12 +62,10 @@ public class ServerExecuterTests {
             final int newport = Utils.findTCPPort();
             TCPServer server = SE.createTCPServer("localhost", newport);
             FakeTCPServerClient clientFC = new FakeTCPServerClient(SE);
-            server.setClientAcceptor(clientFC);
-            server.start();
+            clientFC.addTCPServer(server);
 
             client = SE.createTCPClient("localhost", port);
-            client.setReader(clientFC);
-            client.addCloseListener(clientFC);
+            clientFC.addTCPClient(client);
             client.connect();
 
             synchronized(clients) {

--- a/src/test/java/org/threadly/litesockets/tcp/NoThreadSSLTests.java
+++ b/src/test/java/org/threadly/litesockets/tcp/NoThreadSSLTests.java
@@ -1,20 +1,29 @@
 package org.threadly.litesockets.tcp;
 
+import static org.junit.Assert.*;
+
 import java.io.FileInputStream;
+import java.nio.ByteBuffer;
 import java.security.KeyStore;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.litesockets.Client;
 import org.threadly.litesockets.NoThreadSocketExecuter;
 import org.threadly.litesockets.Server;
+import org.threadly.litesockets.TCPClient;
+import org.threadly.litesockets.TCPServer;
 
 public class NoThreadSSLTests extends SSLTests {
   NoThreadSocketExecuter ntSE;
+  volatile boolean running = true;
   
   @Before
   public void start() throws Exception {
@@ -22,11 +31,14 @@ public class NoThreadSSLTests extends SSLTests {
     ntSE = new NoThreadSocketExecuter(); 
     SE = ntSE;
     SE.start();
-    PS.scheduleWithFixedDelay(new Runnable() {
+    PS.execute(new Runnable() {
       @Override
       public void run() {
         ntSE.select(10);
-      }}, 10, 10);
+        if(running) {
+          PS.execute(this);
+        }
+      }});
     port = Utils.findTCPPort();
     KS = KeyStore.getInstance(KeyStore.getDefaultType());
     String filename = ClassLoader.getSystemClassLoader().getResource("keystore.jks").getFile();
@@ -41,6 +53,7 @@ public class NoThreadSSLTests extends SSLTests {
   
   @After
   public void stop() {
+    running = false;
     for(Server s: serverFC.getAllServers()) {
       s.close();
     }
@@ -48,7 +61,9 @@ public class NoThreadSSLTests extends SSLTests {
     for(Client c: serverFC.getAllClients()) {
       c.close();
     }
-    SE.stop();
+    ntSE.wakeup();
+    ntSE.wakeup();
+    SE.stopIfRunning();
     PS.shutdownNow();
     System.gc();
     System.out.println("Used Memory:"
@@ -62,6 +77,116 @@ public class NoThreadSSLTests extends SSLTests {
       this.stop();
       this.start();
     }
+  }
+  
+  @Test
+  public void simpleInlineSSLtest() throws Exception {
+    NoThreadSocketExecuter lntse = new NoThreadSocketExecuter();
+    lntse.start();
+    TCPServer server = lntse.createTCPServer("localhost", port);
+    server.setSSLContext(sslCtx);
+    server.setDoHandshake(true);
+    serverFC.addTCPServer(server);
+    TCPClient client = lntse.createTCPClient("localhost", port);
+    SSLEngine ssle = sslCtx.createSSLEngine();
+    ssle.setUseClientMode(true);
+    client.setSSLEngine(ssle);
+    client.startSSL();
+    serverFC.addTCPClient(client);
+    final ListenableFuture<?> connected = client.connect();
+    assertFalse(client.isEncrypted());
+    assertFalse(connected.isDone());
+    long start = System.currentTimeMillis();
+    while((!connected.isDone() || !client.isEncrypted()) && System.currentTimeMillis() - start < 5000) {
+      lntse.select(1);
+    }
+    System.out.println(System.currentTimeMillis()-start );
+    assertTrue(System.currentTimeMillis()-start <= 5000);
+    assertTrue(client.isEncrypted());
+    TCPClient sclient = serverFC.getClientAt(1);
+    assertTrue(sclient.isEncrypted());
+    client.write(ByteBuffer.wrap(GET.getBytes()));
+    assertEquals(0, serverFC.getClientsBuffer(sclient).remaining());
+    start = System.currentTimeMillis();
+    while((serverFC.getClientsBuffer(sclient).remaining() == 0) && System.currentTimeMillis() - start < 5000) {
+      lntse.select(1);
+    }
+    String data = serverFC.getClientsBuffer(sclient).getAsString(serverFC.getClientsBuffer(sclient).remaining());
+    assertEquals(GET, data);
+  }
+  
+  @Test
+  public void preDataInlineSSLtest() throws Exception {
+    NoThreadSocketExecuter lntse = new NoThreadSocketExecuter();
+    lntse.start();
+    TCPServer server = lntse.createTCPServer("localhost", port);
+    server.setSSLContext(sslCtx);
+    server.setDoHandshake(true);
+    serverFC.addTCPServer(server);
+    TCPClient client = lntse.createTCPClient("localhost", port);
+    SSLEngine ssle = sslCtx.createSSLEngine();
+    ssle.setUseClientMode(true);
+    client.setSSLEngine(ssle);
+    client.startSSL();
+    serverFC.addTCPClient(client);
+    final ListenableFuture<?> connected = client.connect();
+    assertFalse(client.isEncrypted());
+    assertFalse(connected.isDone());
+    System.out.println("startW");
+    client.write(ByteBuffer.wrap(GET.getBytes()));
+    System.out.println("stopW");
+    long start = System.currentTimeMillis();
+    while((!connected.isDone() || !client.isEncrypted()) && System.currentTimeMillis() - start < 5000) {
+      lntse.select(1);
+    }
+    System.out.println(System.currentTimeMillis()-start );
+    assertTrue(System.currentTimeMillis()-start <= 5000);
+    assertTrue(client.isEncrypted());
+    TCPClient sclient = serverFC.getClientAt(1);
+    assertTrue(sclient.isEncrypted());
+    start = System.currentTimeMillis();
+    while((serverFC.getClientsBuffer(sclient).remaining() == 0) && System.currentTimeMillis() - start < 5000) {
+      lntse.select(1);
+    }
+    String data = serverFC.getClientsBuffer(sclient).getAsString(serverFC.getClientsBuffer(sclient).remaining());
+    assertEquals(GET, data);
+  }
+  
+  @Test
+  public void preDataServerInlineSSLtest() throws Exception {
+    NoThreadSocketExecuter lntse = new NoThreadSocketExecuter();
+    lntse.start();
+    TCPServer server = lntse.createTCPServer("localhost", port);
+    server.setSSLContext(sslCtx);
+    serverFC.addTCPServer(server);
+    TCPClient client = lntse.createTCPClient("localhost", port);
+    SSLEngine ssle = sslCtx.createSSLEngine();
+    ssle.setUseClientMode(true);
+    client.setSSLEngine(ssle);
+    serverFC.addTCPClient(client);
+    final ListenableFuture<?> connected = client.connect();
+    assertFalse(client.isEncrypted());
+    assertFalse(connected.isDone());
+    long start = System.currentTimeMillis();
+    while((!connected.isDone()) && System.currentTimeMillis() - start < 5000) {
+      lntse.select(1);
+    }
+    System.out.println(System.currentTimeMillis()-start );
+    assertTrue(System.currentTimeMillis()-start <= 5000);
+    assertFalse(client.isEncrypted());
+    TCPClient sclient = serverFC.getClientAt(1);
+    assertFalse(sclient.isEncrypted());
+    sclient.startSSL();
+    client.startSSL();
+    System.out.println("startW");
+    sclient.write(ByteBuffer.wrap(GET.getBytes()));
+    System.out.println("endW");
+    start = System.currentTimeMillis();
+    while((serverFC.getClientsBuffer(client).remaining() == 0) && System.currentTimeMillis() - start < 5000) {
+      lntse.select(1);
+    }
+    String data = serverFC.getClientsBuffer(client).getAsString(serverFC.getClientsBuffer(client).remaining());
+    assertEquals(GET, data);
   }
   
   @Override

--- a/src/test/java/org/threadly/litesockets/utils/TransactionalByteBuffersTests.java
+++ b/src/test/java/org/threadly/litesockets/utils/TransactionalByteBuffersTests.java
@@ -129,6 +129,24 @@ public class TransactionalByteBuffersTests {
   }
   
   @Test
+  public void BufferOffestTransaction() {
+    final TransactionalByteBuffers tbb = new TransactionalByteBuffers();
+    ByteBuffer bb = ByteBuffer.allocate(300000);
+    bb.position(50000);
+    bb.put("StringTest1".getBytes());
+    bb.position(50000);
+    bb.limit(bb.position()+11);
+    tbb.add(bb);
+
+    int size = tbb.remaining();
+    tbb.begin();
+    tbb.getAsString(tbb.remaining()-4);
+    tbb.discard(4);
+    tbb.rollback();
+    assertEquals(size, tbb.remaining());
+  }
+  
+  @Test
   public void getShortTest() {
     ByteBuffer bb = ByteBuffer.allocate(20);
     for(int i=0; i<10; i++) {


### PR DESCRIPTION
Found 2 bugs.
1. if the SSLstart was called but not completed and someone wrote data we could get into a bad state.  It was mostly only seen when using the NoThreadSocketExecuter, but could happen with either.
2. TransactionalByteBuffers where not working correctly when we would roll back in situations where a buffers capacity was more then what the limit-position was when we where given the buffer.  Basically we just need to slice() the buffers when we get them to so we know what the actual useable space is in them.