### PR TITLE
Udp fixes

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -282,12 +282,15 @@ public abstract class Client {
    */
   protected void addReadBuffer(final ByteBuffer bb) {
     addReadStats(bb.remaining());
+    int start;
+    int end;
     synchronized(readerLock) {
-      final int start = readBuffers.remaining();
+      start = readBuffers.remaining();
       readBuffers.add(bb);
-      if(this.readerListener.registeredListenerCount() > 0 && readBuffers.remaining() > 0 && start == 0){
-        callReader();
-      }
+      end = readBuffers.remaining();
+    }
+    if(end > 0 && start == 0){
+      callReader();
     }
   }
 

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -33,7 +33,7 @@ import org.threadly.util.Clock;
  *
  */
 public abstract class Client {
-  
+
   /**
    * SocketOptions that can be set set on Clients.
    * 
@@ -44,7 +44,7 @@ public abstract class Client {
   public static enum SocketOption {
     TCP_NODELAY, SEND_BUFFER_SIZE, RECV_BUFFER_SIZE, UDP_FRAME_SIZE, USE_NATIVE_BUFFERS
   }
-  
+
   /**
    * Default max buffer size (64k).  Read and write buffers are independent of each other.
    */
@@ -57,10 +57,10 @@ public abstract class Client {
    * Minimum allowed readBuffer (4k).  If the readBuffer is lower then this we will create a new one.
    */
   protected static final int MIN_READ_BUFFER_SIZE = 4096;
-  
+
   protected static final ByteBuffer EMPTY_BYTEBUFFER = ByteBuffer.allocate(0);
-  
-  private final MergedByteBuffers readBuffers = new MergedByteBuffers(false);
+
+  protected final MergedByteBuffers readBuffers = new MergedByteBuffers(false);
   protected final SocketExecuter se;
   protected final long startTime = Clock.lastKnownForwardProgressingMillis();
   protected final Object readerLock = new Object();
@@ -69,18 +69,16 @@ public abstract class Client {
   protected final AtomicBoolean closed = new AtomicBoolean(false);
   protected final ListenerHelper<Reader> readerListener = ListenerHelper.build(Reader.class);
   protected final ListenerHelper<CloseListener> closerListener = ListenerHelper.build(CloseListener.class);
-  private final boolean combineReadBuffers;
   protected volatile boolean useNativeBuffers = false;
   protected volatile boolean keepReadBuffer = true;
   protected volatile int maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
   protected volatile int newReadBufferSize = NEW_READ_BUFFER_SIZE;
   private ByteBuffer readByteBuffer = EMPTY_BYTEBUFFER;
-  
-  public Client(final SocketExecuter se, boolean combineReadBuffers) {
+
+  public Client(final SocketExecuter se) {
     this.se = se;
-    this.combineReadBuffers = combineReadBuffers;
   }
-  
+
   /**
    * <p>Used by SocketExecuter to set if there was a success or error when connecting, completing the 
    * {@link ListenableFuture}.</p>
@@ -88,7 +86,7 @@ public abstract class Client {
    * @param t if there was an error connecting this is provided otherwise a successful connect will pass {@code null}.
    */
   protected abstract void setConnectionStatus(Throwable t);
-  
+
   /**
    * <p>This provides the next available Write buffer.  This is typically only called by the {@link SocketExecuter}.
    * This is not threadsafe as the same {@link ByteBuffer} will be provided to any thread that calls this, until 
@@ -101,7 +99,7 @@ public abstract class Client {
    * @return a {@link ByteBuffer} that can be used to Read new data off the socket for this client.
    */
   protected abstract ByteBuffer getWriteBuffer();
-  
+
   /**
    * <p>This is called after a write is written to the clients socket.  This tells the client how much of that 
    * {@link ByteBuffer} was written and then reduces the writeBuffersSize accordingly.</p>
@@ -109,7 +107,7 @@ public abstract class Client {
    * @param size the size in bytes of data written on the socket.
    */
   protected abstract void reduceWrite(int size);
-  
+
   /**
    * <p>Gets the raw Socket object for this Client. If the client does not have a Socket
    * it will return null (ie {@link UDPClient}). This is basically getChannel().socket()</p>
@@ -125,20 +123,20 @@ public abstract class Client {
    * @return the {@link SocketChannel}  for this client.
    */
   protected abstract SocketChannel getChannel();
-  
+
   /**
    * 
    * @return the remote {@link SocketAddress} this client is connected to.
    */
   public abstract SocketAddress getRemoteSocketAddress();
-  
-  
+
+
   /**
    * 
    * @return the local {@link SocketAddress} this client is using.
    */
   public abstract SocketAddress getLocalSocketAddress();
-  
+
 
   /**
    * Returns true if this client has data pending in its write buffers.  False if there is no data pending write.
@@ -154,7 +152,7 @@ public abstract class Client {
    * @return false if the client has been connected, true if it has not connected and the timeout limit has been reached.
    */
   public abstract boolean hasConnectionTimedOut();
-  
+
   /**
    * <p>This lets you set lower level socket options for this client.  Mainly Buffer sizes and no delay options.</p>
    * 
@@ -165,9 +163,9 @@ public abstract class Client {
    */
   @Deprecated
   public abstract boolean setSocketOption(SocketOption so, int value);
-  
+
   public abstract ClientOptions clientOptions();
-  
+
   /**
    * 
    * <p>Called to connect this client to a host.  This is done non-blocking.</p>
@@ -177,29 +175,29 @@ public abstract class Client {
    * @return A {@link ListenableFuture} that will complete when the socket is connected, or fail if we cant connect.
    */
   public abstract ListenableFuture<Boolean> connect();
-  
+
   /**
    * Sets the connection timeout value for this client.  This must be called before {@link #connect()} has called on this client.  
    * 
    * @param timeout the time in milliseconds to wait for the client to connect.
    */
   public abstract void setConnectionTimeout(int timeout);
-  
+
   /**
    * <p>Used to get this clients connection timeout information.</p>
    * 
    * @return the max amount of time to wait for a connection to connect on this socket.
    */
   public abstract int getTimeout();
-  
-  
+
+
   /**
    * <p>This is used to get the current size of the unWriten writeBuffer.</p>
    * 
    * @return the current size of the writeBuffer.
    */
   public abstract int getWriteBufferSize();
-  
+
   /**
    * <p>This is used by the {@link SocketExecuter} to help understand how to manage this client.
    * Currently only UDP and TCP exist.</p>
@@ -207,7 +205,7 @@ public abstract class Client {
    * @return The IP protocol type of this client.
    */
   public abstract WireProtocol getProtocol();
-  
+
   /**
    * <p>This is called to write data to the clients socket.  Its important to note that there is no back
    * pressure when adding writes so care should be taken to now allow the clients {@link #getWriteBufferSize()} to get
@@ -217,18 +215,18 @@ public abstract class Client {
    * @return A {@link ListenableFuture} that will be completed once the data has been fully written to the socket.
    */
   public abstract ListenableFuture<?> write(ByteBuffer bb);
-  
+
   /**
    * <p>Closes this client.  Reads can still occur after this it called.  {@link CloseListener#onClose(Client)} will still be
    * called (if set) once all reads are done.</p>
    */
   public abstract void close();
-  
-  
+
+
   protected void addReadStats(final int size) {
     stats.addRead(size);
   }
-  
+
   protected void addWriteStats(final int size) {
     stats.addWrite(size);
   }
@@ -257,9 +255,9 @@ public abstract class Client {
         return ByteBuffer.allocate(newReadBufferSize);
       }
     }
-    
+
   }
-  
+
   /**
    * <p>This is used to get the currently set {@link Closer} for this client.</p>
    * 
@@ -268,11 +266,11 @@ public abstract class Client {
   protected void callClosers() {
     this.closerListener.call().onClose(this);
   }
-  
+
   protected void callReader() {
     this.readerListener.call().onRead(this);
   }
-  
+
   /**
    * 
    * <p>Adds a {@link ByteBuffer} to the Clients readBuffer.  This is normally only used by the {@link SocketExecuter},
@@ -287,12 +285,12 @@ public abstract class Client {
     synchronized(readerLock) {
       final int start = readBuffers.remaining();
       readBuffers.add(bb);
-      if(!this.combineReadBuffers || (this.readerListener.registeredListenerCount() > 0 && readBuffers.remaining() > 0 && start == 0)){
+      if(this.readerListener.registeredListenerCount() > 0 && readBuffers.remaining() > 0 && start == 0){
         callReader();
       }
     }
   }
-  
+
   /**
    * Returns true if this client can have reads added to it or false if its read buffers are full.
    * 
@@ -302,7 +300,7 @@ public abstract class Client {
   public boolean canRead() {
     return readBuffers.remaining() < maxBufferSize;
   }
-  
+
   /**
    * <p>This is used to get the current size of the readBuffers pending reads.</p>
    * 
@@ -311,7 +309,7 @@ public abstract class Client {
   public int getReadBufferSize() {
     return readBuffers.remaining();
   }
-  
+
   /**
    * This is used to get the currently set max buffer size.
    * 
@@ -320,7 +318,7 @@ public abstract class Client {
   public int getMaxBufferSize() {
     return this.maxBufferSize;
   }
-  
+
   /**
    * <p> This returns this clients {@link Executor}.</p>
    * 
@@ -332,7 +330,7 @@ public abstract class Client {
   public Executor getClientsThreadExecutor() {
     return se.getExecutorFor(this);
   }
-  
+
   /**
    * <p>This is used to get the clients {@link SocketExecuter}.</p>
    * 
@@ -407,22 +405,15 @@ public abstract class Client {
    */
   public MergedByteBuffers getRead() {
     MergedByteBuffers mbb = null;
-    if(this.combineReadBuffers) {
-      synchronized(readerLock) {
-        mbb = readBuffers.duplicateAndClean();
-      }
-    } else {
-      mbb = new MergedByteBuffers();
-      synchronized(readerLock) {
-        mbb.add(readBuffers.pop());
-      }
+    synchronized(readerLock) {
+      mbb = readBuffers.duplicateAndClean();
     }
     if(mbb.remaining() >= maxBufferSize) {
       se.setClientOperations(this);
     }
     return mbb;
   }
-  
+
   /**
    * <p>Returns if this client is closed or not.  Once a client is marked closed there is no way to reOpen it.
    * You must just make a new client.  Just because this returns false does not mean the client is connected.
@@ -433,11 +424,11 @@ public abstract class Client {
   public boolean isClosed() {
     return closed.get();
   }
-  
+
   protected boolean setClose() {
     return closed.compareAndSet(false, true);
   }
-  
+
   /**
    * Returns the {@link SimpleByteStats} for this client.
    * 
@@ -446,7 +437,7 @@ public abstract class Client {
   public SimpleByteStats getStats() {
     return stats;
   }
-  
+
   /**
    * Implementation of the SimpleByteStats.
    */
@@ -460,14 +451,14 @@ public abstract class Client {
       ArgumentVerifier.assertNotNegative(size, "size");
       super.addWrite(size);
     }
-    
+
     @Override
     protected void addRead(final int size) {
       ArgumentVerifier.assertNotNegative(size, "size");
       super.addRead(size);
     }
   }
-  
+
   /**
    * Used to notify when a Client there is data to Read for a Client.
    * 
@@ -495,8 +486,8 @@ public abstract class Client {
      */
     public void onRead(Client client);
   }
-  
-  
+
+
   /**
    * Used to notify when a Client is closed.
    * 
@@ -513,7 +504,7 @@ public abstract class Client {
      */
     public void onClose(Client client);
   }
-  
+
   /**
    * ClientOptions that can be changed depending on what kind of client you want.
    * 
@@ -523,7 +514,7 @@ public abstract class Client {
    *
    */
   public interface ClientOptions {
-    
+
     /**
      * This is only available for connection backed by a TCP socket.
      * It will turn on TcpNoDelay on the the connection at the System level.
@@ -533,14 +524,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setTcpNoDelay(boolean enabled);
-    
+
     /**
      * Returns the current state of TcpNoDelay.
      * 
      * @return true means NoDelay is on, false means NoDelay is off.
      */
     public boolean getTcpNoDelay();
-    
+
     /**
      * Sets this client to use Native or Direct ByteBuffers.
      * This can save allocations to the Heap, but is generally only useful
@@ -550,14 +541,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setNativeBuffers(boolean enabled);
-    
+
     /**
      * Returns the current state of native buffers.
      * 
      * @return true means native buffers are generated false means they are not. 
      */
     public boolean getNativeBuffers();
-    
+
     /**
      * Sets reduced Read buffer allocations.  This is accomplished by over allocating 
      * the read buffer and returning subsets of it.  This can make reads much faster but
@@ -567,14 +558,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setReducedReadAllocations(boolean enabled);
-    
+
     /**
      * Returns the current state of ReducedReadAllocations.
      * 
      * @return true for enabled false for disabled.
      */
     public boolean getReducedReadAllocations();
-    
+
     /**
      * Sets the max size of read buffer the client is allowed to have.
      * Once this is reached the client will stop doing read operations until 
@@ -585,14 +576,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setMaxClientReadBuffer(int size);
-    
+
     /**
      * Returns the currently set max Read buffer size in Bytes.
      * 
      * @return size of max read buffer size.
      */
     public int getMaxClientReadBuffer();
-    
+
     /**
      * Sets the size of the ByteBuffer used for Reads.  The larger this
      * buffer is the more data we can read from the socket at once.  If
@@ -603,14 +594,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setReadAllocationSize(int size);
-    
+
     /**
      * Returns the current Read buffer allocation size in bytes.
      * 
      * @return bytes allocated for reads.
      */
     public int getReadAllocationSize();
-    
+
     /**
      * This sets the System level socket send buffer size.  Every OS
      * has its own min and max values for this, if you go over or under that
@@ -620,14 +611,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setSocketSendBuffer(int size);
-    
+
     /**
      * Returns the currently set send buffer size in bytes.
      * 
      * @return send buffer size in bytes.
      */
     public int getSocketSendBuffer();
-    
+
     /**
      * This sets the System level socket receive buffer size.  Every OS
      * has its own min and max values for this, if you go over or under that
@@ -637,14 +628,14 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setSocketRecvBuffer(int size);
-    
+
     /**
      * Returns the currently set receive buffer size in bytes.
      * 
      * @return send buffer size in bytes.
      */
     public int getSocketRecvBuffer();
-    
+
     /**
      * Sets the UDP frame size.  This only possible on UDP backed clients.
      * 
@@ -652,7 +643,7 @@ public abstract class Client {
      * @return true if this was able to be set.
      */
     public boolean setUdpFrameSize(int size);
-    
+
     /**
      * Returns the currently set UDP frame size in bytes.
      * 
@@ -660,14 +651,14 @@ public abstract class Client {
      */
     public int getUdpFrameSize();
   }
-  
+
   /**
    * 
    * @author lwahlmeier
    *
    */
   protected class BaseClientOptions implements ClientOptions {
-    
+
     @Override
     public boolean setNativeBuffers(boolean enabled) {
       useNativeBuffers = enabled;
@@ -678,7 +669,7 @@ public abstract class Client {
     public boolean getNativeBuffers() {
       return useNativeBuffers;
     }
-    
+
     @Override
     public boolean setReducedReadAllocations(boolean enabled) {
       keepReadBuffer = enabled;
@@ -692,7 +683,7 @@ public abstract class Client {
     public boolean getReducedReadAllocations() {
       return keepReadBuffer;
     }
-    
+
     @Override
     public boolean setReadAllocationSize(int size) {
       newReadBufferSize = size;
@@ -703,7 +694,7 @@ public abstract class Client {
     public int getReadAllocationSize() {
       return newReadBufferSize;
     }
-    
+
     @Override
     public boolean setMaxClientReadBuffer(int size) {
       maxBufferSize = size;

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -151,7 +151,18 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
                   }
                 } 
                 if(key.isWritable()) {
-                  stats.addWrite(doClientWrite(tmpClient, commonSelector));
+                  if(tmpClient != null){
+                    stats.addWrite(doClientWrite(tmpClient, commonSelector));
+                  } else {
+                    final Server server = servers.get(key.channel());
+                    if(server != null) {
+                      if(server instanceof UDPServer) {
+                        UDPServer us = (UDPServer) server;
+                        stats.addWrite(us.doWrite());
+                        startListening(us);
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/src/main/java/org/threadly/litesockets/SocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuter.java
@@ -107,6 +107,8 @@ public interface SocketExecuter extends Service {
    */
   public void stopListening(Server server);
   
+  public void setUDPServerOperations(UDPServer udpServer, boolean enable);
+  
   /**
    * <p>Get the count of {@link Client} on this SocketExecuter.</p>
    * 

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -57,7 +57,7 @@ public class TCPClient extends Client {
    * @throws IOException - This is thrown if there are any problems making the socket.
    */
   protected TCPClient(final SocketExecuter sei, final String host, final int port) throws IOException {
-    super(sei, true);
+    super(sei);
     remoteAddress = new InetSocketAddress(host, port);
     channel = SocketChannel.open();
     channel.configureBlocking(false);
@@ -72,7 +72,7 @@ public class TCPClient extends Client {
    * @throws IOException if there is anything wrong with the {@link SocketChannel} this will be thrown.
    */
   protected TCPClient(final SocketExecuter sei, final SocketChannel channel) throws IOException {
-    super(sei, true);
+    super(sei);
     if(! channel.isOpen()) {
       throw new ClosedChannelException();
     }

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -57,7 +57,7 @@ public class TCPClient extends Client {
    * @throws IOException - This is thrown if there are any problems making the socket.
    */
   protected TCPClient(final SocketExecuter sei, final String host, final int port) throws IOException {
-    super(sei);
+    super(sei, true);
     remoteAddress = new InetSocketAddress(host, port);
     channel = SocketChannel.open();
     channel.configureBlocking(false);
@@ -72,7 +72,7 @@ public class TCPClient extends Client {
    * @throws IOException if there is anything wrong with the {@link SocketChannel} this will be thrown.
    */
   protected TCPClient(final SocketExecuter sei, final SocketChannel channel) throws IOException {
-    super(sei);
+    super(sei, true);
     if(! channel.isOpen()) {
       throw new ClosedChannelException();
     }

--- a/src/main/java/org/threadly/litesockets/UDPClient.java
+++ b/src/main/java/org/threadly/litesockets/UDPClient.java
@@ -35,7 +35,7 @@ public class UDPClient extends Client {
   
 
   protected UDPClient(final InetSocketAddress sa, final UDPServer server) {
-    super(server.getSocketExecuter());
+    super(server.getSocketExecuter(), false);
     this.remoteAddress = sa;
     udpServer = server;
   }

--- a/src/main/java/org/threadly/litesockets/UDPClient.java
+++ b/src/main/java/org/threadly/litesockets/UDPClient.java
@@ -182,8 +182,8 @@ public class UDPClient extends Client {
     addReadStats(bb.remaining());
     synchronized(readerLock) {
       readBuffers.add(bb);
-      callReader();
     }
+    callReader();
   }
   
   @Override

--- a/src/main/java/org/threadly/litesockets/UDPServer.java
+++ b/src/main/java/org/threadly/litesockets/UDPServer.java
@@ -51,7 +51,6 @@ public class UDPServer extends Server {
       try {
         final InetSocketAddress isa = (InetSocketAddress)channel.receive(bb);
         bb.flip();
-        System.out.println("READ:"+bb);
         getSocketExecuter().getThreadScheduler().execute(new NewDataRunnable(this, isa, bb));
       } catch (IOException e) {
 
@@ -166,6 +165,11 @@ public class UDPServer extends Server {
     
   }
   
+  /**
+   * 
+   * @author lwahlmeier
+   *
+   */
   private static class WriteDataPair {
     private final ByteBuffer bb;
     private final InetSocketAddress isa;

--- a/src/main/java/org/threadly/litesockets/utils/MergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/utils/MergedByteBuffers.java
@@ -144,7 +144,6 @@ public class MergedByteBuffers {
 
     while(mbb.remaining() >= pattern.length-patPos) {
       prevMatched[patPos] = mbb.get();
-      //System.out.println(patPos+":"+bufPos+":"+mbb.remaining());
       if(pattern[patPos] == prevMatched[patPos]) {
         if(patPos == pattern.length-1) {
           return bufPos;
@@ -157,7 +156,6 @@ public class MergedByteBuffers {
           bb.position(1);
           bb.limit(patPos+1);
           if(bb.remaining() > 0) {
-            //System.out.println("-----"+bb.remaining()+":"+patPos+":"+bufPos);
             mbb.addFront(bb);
           }
           prevMatched = new byte[pattern.length];
@@ -414,6 +412,11 @@ public class MergedByteBuffers {
         removeFirstBuffer();
       }
     }
+  }
+  
+  @Override
+  public String toString() {
+    return "MergedByteBuffer size:"+currentSize+": queueSize"+availableBuffers.size()+": consumed:"+consumedSize;
   }
 
   /**

--- a/src/main/java/org/threadly/litesockets/utils/MergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/utils/MergedByteBuffers.java
@@ -47,30 +47,17 @@ public class MergedByteBuffers {
    */
   public void add(final ByteBuffer buffer) {
     if(buffer.hasRemaining()) {
-      ByteBuffer bb = buffer.slice();
-      if(this.markReadOnly) {
-        availableBuffers.add(bb.asReadOnlyBuffer());
+      if(markReadOnly) {
+        doAdd(buffer.slice().asReadOnlyBuffer());
       } else {
-        availableBuffers.add(bb);
+        doAdd(buffer.slice());
       }
-      currentSize+=buffer.remaining();
     } 
   }
   
-  
-  /**
-   * Make a complete copy of this MergedByteBuffer.  Both references should function independently, but
-   * they are still using the same ByteBuffer backing arrays so any change to the actual byte[] in the 
-   * backing ByteBuffers will change in both.
-   * 
-   * @return a new MergedByteBuffers object that duplicates this one, but works independently.
-   */
-  public MergedByteBuffers copy() {
-    final MergedByteBuffers mbb  = new MergedByteBuffers();
-    for(final ByteBuffer bb: this.availableBuffers) {
-      mbb.add(bb.duplicate());
-    }
-    return mbb;
+  private void doAdd(final ByteBuffer bb) {
+    availableBuffers.add(bb);
+    currentSize+=bb.remaining();
   }
   
   /**
@@ -86,6 +73,21 @@ public class MergedByteBuffers {
     mbb.availableBuffers.clear();
     mbb.consumedSize += mbb.currentSize;
     mbb.currentSize = 0;
+  }
+  
+  /**
+   * Make a complete copy of this MergedByteBuffer.  Both references should function independently, but
+   * they are still using the same ByteBuffer backing arrays so any change to the actual byte[] in the 
+   * backing ByteBuffers will change in both.
+   * 
+   * @return a new MergedByteBuffers object that duplicates this one, but works independently.
+   */
+  public MergedByteBuffers copy() {
+    final MergedByteBuffers mbb  = new MergedByteBuffers();
+    for(final ByteBuffer bb: this.availableBuffers) {
+      mbb.add(bb.duplicate());
+    }
+    return mbb;
   }
   
   /**

--- a/src/test/java/org/threadly/litesockets/udp/FakeUDPServerClient.java
+++ b/src/test/java/org/threadly/litesockets/udp/FakeUDPServerClient.java
@@ -37,6 +37,7 @@ public class FakeUDPServerClient implements CloseListener, Reader, ClientAccepto
   @Override
   public void accept(Client c) {
     UDPClient uc = (UDPClient) c;
+    System.out.println("New Client:"+this);
     uc.setReader(this);
     uc.addCloseListener(this);
     clients.put(uc, new MergedByteBuffers());

--- a/src/test/java/org/threadly/litesockets/udp/FakeUDPServerClient.java
+++ b/src/test/java/org/threadly/litesockets/udp/FakeUDPServerClient.java
@@ -52,6 +52,7 @@ public class FakeUDPServerClient implements CloseListener, Reader, ClientAccepto
     if(mbb != null) {
       mbb.add(bb);
     }
+    System.out.println("Got Read:"+mbb.remaining());
   }
 
   @Override

--- a/src/test/java/org/threadly/litesockets/udp/UDPTest.java
+++ b/src/test/java/org/threadly/litesockets/udp/UDPTest.java
@@ -132,9 +132,10 @@ public class UDPTest {
     new TestCondition(){
       @Override
       public boolean get() {
+        System.out.println(serverFC.clientList.size()+":"+serverFC);
         return serverFC.clientList.size() == 10;
       }
-    }.blockTillTrue(5000);
+    }.blockTillTrue(5000, 200);
 
     new TestCondition(){
       @Override


### PR DESCRIPTION
UDP was not quite working correctly.  We need to make sure we get a read event per udpFrame since alot of udp protocol uses that and does not pass a length.

I also moved UDP writes to go through the write selector, before we would just write then directly to the socket and hope for the best, but now we actually check that we can write before we do that.

The UDPServer reads where happening on the Acceptor thread, this has been moved to the readerThread.