### PR TITLE
Update to latest threadly version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.0.0-SNAPSHOT
-threadlyVersion = 4.4.3
+version = 3.2.0
+threadlyVersion = 4.6.0

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -67,8 +67,9 @@ public abstract class Client {
   protected final Object writerLock = new Object();
   protected final ClientByteStats stats = new ClientByteStats();
   protected final AtomicBoolean closed = new AtomicBoolean(false);
-  protected final ListenerHelper<Reader> readerListener = ListenerHelper.build(Reader.class);
-  protected final ListenerHelper<CloseListener> closerListener = ListenerHelper.build(CloseListener.class);
+  protected final ListenerHelper<Reader> readerListener = new ListenerHelper<Reader>(Reader.class);
+  protected final ListenerHelper<CloseListener> closerListener = 
+      new ListenerHelper<CloseListener>(CloseListener.class);
   protected volatile boolean useNativeBuffers = false;
   protected volatile boolean keepReadBuffer = true;
   protected volatile int maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -6,9 +6,9 @@ import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.concurrent.Executor;
 
 import org.threadly.concurrent.NoThreadScheduler;
+import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.util.ArgumentVerifier;
 
 /**
@@ -202,7 +202,7 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
   }
 
   @Override
-  public Executor getExecutorFor(final Object obj) {
+  public SubmitterExecutor getExecutorFor(final Object obj) {
     return localNoThreadScheduler;
   }
 }

--- a/src/main/java/org/threadly/litesockets/Server.java
+++ b/src/main/java/org/threadly/litesockets/Server.java
@@ -21,7 +21,8 @@ public abstract class Server {
   private final SocketExecuter sei;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private volatile ClientAcceptor clientAcceptor;
-  private volatile ListenerHelper<ServerCloseListener> closer = ListenerHelper.build(ServerCloseListener.class);
+  private volatile ListenerHelper<ServerCloseListener> closer = 
+      new ListenerHelper<ServerCloseListener>(ServerCloseListener.class);
   
   protected Server(final SocketExecuter sei) {
     this.sei = sei;

--- a/src/main/java/org/threadly/litesockets/SocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuter.java
@@ -3,8 +3,8 @@ package org.threadly.litesockets;
 import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.concurrent.Executor;
 
+import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.concurrent.SubmitterScheduler;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.litesockets.utils.SimpleByteStats;
@@ -77,9 +77,9 @@ public interface SocketExecuter extends Service {
    * This allows you to get the {@link Executor} for a specified object.
    * 
    * @param obj The Object whose {@link Executor} you are looking for
-   * @return the {@link Executor} for that object.
+   * @return the {@link SubmitterExecutor} for that object.
    */
-  public Executor getExecutorFor(Object obj);
+  public SubmitterExecutor getExecutorFor(Object obj);
   
   /**
    * This is called when the a clients state needs to be rechecked.  It will cause the SocketExecuter to 

--- a/src/main/java/org/threadly/litesockets/ThreadedSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/ThreadedSocketExecuter.java
@@ -4,14 +4,14 @@ import java.nio.channels.CancelledKeyException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.threadly.concurrent.ConfigurableThreadFactory;
-import org.threadly.concurrent.KeyDistributedExecutor;
-import org.threadly.concurrent.ScheduledExecutorServiceWrapper;
 import org.threadly.concurrent.SingleThreadScheduler;
+import org.threadly.concurrent.SubmitterExecutor;
 import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.concurrent.wrapper.KeyDistributedExecutor;
+import org.threadly.concurrent.wrapper.compatibility.ScheduledExecutorServiceWrapper;
 import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.ExceptionUtils;
 
@@ -271,7 +271,7 @@ public class ThreadedSocketExecuter extends SocketExecuterCommonBase {
   }
 
   @Override
-  public Executor getExecutorFor(final Object obj) {
-    return clientDistributer.getSubmitterForKey(obj);
+  public SubmitterExecutor getExecutorFor(final Object obj) {
+    return clientDistributer.getExecutorForKey(obj);
   }
 }


### PR DESCRIPTION
This updates off deprecated API's for the latest threadly version.
It also makes it so that the returned Executor is the more full featured `SubmitterExecutor` (which is easy to transition to).
I updated the version to 3.2.0 so that we can release in this state.

If it looks good go ahead and merge, and I will release 3.2.0 to MC