### PR TITLE
ReusableMergedByteBuffers: Fix NullPointerException when constructed with buffers

### DIFF
--- a/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
@@ -28,11 +28,6 @@ public abstract class AbstractMergedByteBuffers implements MergedByteBuffers {
     this.markReadOnly = readOnly;
   }
   
-  public AbstractMergedByteBuffers(boolean readOnly, ByteBuffer ...bbs) {
-    this.markReadOnly = readOnly;
-    add(bbs);
-  }
-  
   protected abstract void doAppend(final ByteBuffer bb);
   protected abstract void addToFront(final ByteBuffer bb);
   protected abstract byte get(int pos);

--- a/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
@@ -33,7 +33,9 @@ public class ReuseableMergedByteBuffers extends AbstractMergedByteBuffers {
   }
   
   public ReuseableMergedByteBuffers(boolean readOnly, ByteBuffer ...bbs) {
-    super(readOnly, bbs);
+    super(readOnly);
+    
+    add(bbs);
   }
   
   @Override

--- a/src/test/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffersTests.java
+++ b/src/test/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffersTests.java
@@ -19,6 +19,16 @@ public class ReuseableMergedByteBuffersTests {
   }
   
   @Test
+  public void constructWithBuffersTest() {
+    ByteBuffer bb = ByteBuffer.wrap("vsdljsakd".getBytes());
+    MergedByteBuffers mbb = new ReuseableMergedByteBuffers(false, bb);
+    assertEquals(bb.remaining(), mbb.remaining());
+    while (mbb.hasRemaining()) {
+      assertEquals(bb.get(), mbb.get());
+    }
+  }
+  
+  @Test
   public void indexPatternTest() {
     String st = "HTTP/1.1 101 Switching Protocols\r\nAccept: */*\r\nSec-WebSocket-Accept: W5bRv0dwYtd1GPxLJnXACYizcbU=\r\nUser-Agent: litesockets\r\n\r\n";
     MergedByteBuffers mbb = new ReuseableMergedByteBuffers();


### PR DESCRIPTION
This adds a test that previously would fail with a NPE, but now works with the provided fix.
The issue is that fields initialized in the extending class will not be initialized before the super constructor has completed (which is what is invoking to add).
This constructor is thus just problematic and was removed, putting the add burden on the `ReuseableMergedByteBuffers`.

@lwahlmeier This has already been released as a snapshot artifact, go ahead and merge if you are good with it.