### PR TITLE
Better handling for internal exceptions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.0.0-SNAPSHOT
+version = 4.0-SNAPSHOT
 threadlyVersion = 5.1

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.threadly</groupId>
   <artifactId>litesockets</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>LiteSockets</name>

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -222,8 +222,7 @@ public abstract class Client implements Closeable {
    * 
    * @param error The error that resulted in us closing this client, or {@code null} if closing normally
    */
-  protected abstract void close(Throwable error);
-
+  public abstract void close(Throwable error);
 
   /*Implemented functions*/
   
@@ -493,8 +492,11 @@ public abstract class Client implements Closeable {
 
     /**
      * This notifies the callback about the client being closed due to an exception.  Typically 
-     * these might represent a {@link java.util.io.IOException} from the connection being closed 
-     * during a read. 
+     * these might represent a {@code IOException} from the connection being closed during a read. 
+     * 
+     * <p>By default this will invoked {@link ExceptionUtils#handleException(Throwable)} and then 
+     * invoke {@link #clone()}.  If you override this you must also invoke {@link #close()} if you 
+     * want that logic shared / reused during an error condition.</p>
      * 
      * @param client This is the client the close is being called for.
      * @param error The exception which resulted in the client closing

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -108,7 +108,7 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
       try {
         localNoThreadScheduler.tick(null);
       } catch(Exception e) {
-
+        ExceptionUtils.handleException(e);
       }
     }
     clients.clear();
@@ -142,8 +142,8 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
       } else {
         sk.interestOps(0);
       }
-    } catch(Exception e) {
-      e.printStackTrace();
+    } catch(Throwable t) {
+      client.close(t);
     }
   }
 
@@ -198,9 +198,8 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
                         tmpClient.setConnectionStatus(null);
                       }
                     } catch(IOException e) {
-                      IOUtils.closeQuietly(tmpClient);
+                      tmpClient.close(e);
                       tmpClient.setConnectionStatus(e);
-                      ExceptionUtils.handleException(e);
                     }
                   } else {
                     if (key.isReadable()) {

--- a/src/main/java/org/threadly/litesockets/Server.java
+++ b/src/main/java/org/threadly/litesockets/Server.java
@@ -5,6 +5,7 @@ import java.nio.channels.SelectableChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.threadly.concurrent.event.ListenerHelper;
+import org.threadly.util.ExceptionUtils;
 
 /**
  * This is the main Server Interface for litesockets.  
@@ -18,12 +19,11 @@ import org.threadly.concurrent.event.ListenerHelper;
  *
  */
 public abstract class Server implements Closeable {
-  
   protected final SocketExecuterCommonBase sei;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private volatile ClientAcceptor clientAcceptor;
   private volatile ListenerHelper<ServerCloseListener> closer = 
-      new ListenerHelper<ServerCloseListener>(ServerCloseListener.class);
+      new ListenerHelper<>(ServerCloseListener.class);
   
   protected Server(final SocketExecuterCommonBase sei) {
     this.sei = sei;
@@ -45,11 +45,19 @@ public abstract class Server implements Closeable {
    */
   protected abstract SelectableChannel getSelectableChannel();
   
-  
   /**
    * <p>Close this servers Socket.  Once closed you must construct a new Server to open it again.</p>
    */
-  public abstract void close();
+  public void close() {
+    close(null);
+  }
+
+  /**
+   * <p>Close this servers Socket.  Once closed you must construct a new Server to open it again.</p>
+   * 
+   * @param error The error that resulted in us closing this server, or {@code null} if closing normally
+   */
+  protected abstract void close(Throwable error);
   
   /**
    * <p>This is used by the {@link SocketExecuter} to know how to handle this Server 
@@ -67,10 +75,14 @@ public abstract class Server implements Closeable {
   /**
    * <p>Get the current ServerCloser callback assigned to this Server.</p>
    * 
-   * @return the currently set Closer.
+   * @param t Error that initiated the close, or {@code null} if closed normally
    */
-  protected void callClosers() {
-    this.closer.call().onClose(this);
+  protected void callClosers(Throwable t) {
+    if (t == null) {
+      this.closer.call().onClose(this);
+    } else {
+      this.closer.call().onCloseWithError(this, t);
+    }
   }
 
   /**
@@ -154,16 +166,24 @@ public abstract class Server implements Closeable {
    * 
    * <p>This is called once a Close is detected on the Servers Socket. Since it can happen on any thread as well
    * you might get new clients for this server shortly after it closes.</p>
-   * 
-   *
    */
   public interface ServerCloseListener {
     /**
-     * Once a close is detected for this {@link Server} this is called..
+     * Invoked once the provided server has been detected to be in a closed state.
      * 
      * @param server The {@link Server} that has been closed.
      */
     public void onClose(Server server);
-  }
 
+    /**
+     * Invoked once the provided server has been closed due to an error.
+     * 
+     * @param server The {@link Server} that has been closed.
+     * @param error The exception which resulted in the client closing
+     */
+    public default void onCloseWithError(Server server, Throwable error) {
+      ExceptionUtils.handleException(error);
+      onClose(server);
+    }
+  }
 }

--- a/src/main/java/org/threadly/litesockets/Server.java
+++ b/src/main/java/org/threadly/litesockets/Server.java
@@ -57,7 +57,7 @@ public abstract class Server implements Closeable {
    * 
    * @param error The error that resulted in us closing this server, or {@code null} if closing normally
    */
-  protected abstract void close(Throwable error);
+  public abstract void close(Throwable error);
   
   /**
    * <p>This is used by the {@link SocketExecuter} to know how to handle this Server 
@@ -177,6 +177,10 @@ public abstract class Server implements Closeable {
 
     /**
      * Invoked once the provided server has been closed due to an error.
+     * 
+     * <p>By default this will invoked {@link ExceptionUtils#handleException(Throwable)} and then 
+     * invoke {@link #clone()}.  If you override this you must also invoke {@link #close()} if you 
+     * want that logic shared / reused during an error condition.</p>
      * 
      * @param server The {@link Server} that has been closed.
      * @param error The exception which resulted in the client closing

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -142,7 +142,7 @@ public class TCPClient extends Client {
   }
 
   @Override
-  public void close() {
+  protected void close(Throwable error) {
     if(setClose()) {
       se.setClientOperations(this);
       this.getClientsThreadExecutor().execute(new Runnable() {
@@ -159,7 +159,7 @@ public class TCPClient extends Client {
             writeBuffers.discard(writeBuffers.remaining());
           }
         }});
-      this.callClosers();
+      this.callClosers(error);
     }
   }
 

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -142,7 +142,7 @@ public class TCPClient extends Client {
   }
 
   @Override
-  protected void close(Throwable error) {
+  public void close(Throwable error) {
     if(setClose()) {
       se.setClientOperations(this);
       this.getClientsThreadExecutor().execute(new Runnable() {

--- a/src/main/java/org/threadly/litesockets/TCPServer.java
+++ b/src/main/java/org/threadly/litesockets/TCPServer.java
@@ -55,7 +55,7 @@ public class TCPServer extends Server {
   }
 
   @Override
-  protected void close(Throwable error) {
+  public void close(Throwable error) {
     if(this.setClosed()) {
       getSocketExecuter().stopListening(this);
       IOUtils.closeQuietly(socket);

--- a/src/main/java/org/threadly/litesockets/TCPServer.java
+++ b/src/main/java/org/threadly/litesockets/TCPServer.java
@@ -55,11 +55,11 @@ public class TCPServer extends Server {
   }
 
   @Override
-  public void close() {
+  protected void close(Throwable error) {
     if(this.setClosed()) {
       getSocketExecuter().stopListening(this);
       IOUtils.closeQuietly(socket);
-      callClosers();
+      callClosers(error);
     }
   }
 

--- a/src/main/java/org/threadly/litesockets/UDPClient.java
+++ b/src/main/java/org/threadly/litesockets/UDPClient.java
@@ -103,9 +103,9 @@ public class UDPClient extends Client {
   }
 
   @Override
-  public void close() {
+  protected void close(Throwable error) {
     if(this.setClose()) {
-      callClosers();
+      callClosers(error);
     }
   }
 

--- a/src/main/java/org/threadly/litesockets/UDPClient.java
+++ b/src/main/java/org/threadly/litesockets/UDPClient.java
@@ -103,7 +103,7 @@ public class UDPClient extends Client {
   }
 
   @Override
-  protected void close(Throwable error) {
+  public void close(Throwable error) {
     if(this.setClose()) {
       callClosers(error);
     }

--- a/src/main/java/org/threadly/litesockets/UDPServer.java
+++ b/src/main/java/org/threadly/litesockets/UDPServer.java
@@ -150,7 +150,7 @@ public class UDPServer extends Server {
   }
 
   @Override
-  protected void close(Throwable error) {
+  public void close(Throwable error) {
     if(setClosed()) {
       IOUtils.closeQuietly(channel);
       this.callClosers(error);

--- a/src/main/java/org/threadly/litesockets/UDPServer.java
+++ b/src/main/java/org/threadly/litesockets/UDPServer.java
@@ -37,10 +37,10 @@ public class UDPServer extends Server {
    */
   public static enum UDPFilterMode {WhiteList, BlackList};
 
-  private final ConcurrentHashMap<InetSocketAddress, UDPClient> clients = new ConcurrentHashMap<InetSocketAddress, UDPClient>();
-  private final ConcurrentLinkedQueue<Pair<InetSocketAddress, ByteBuffer>> writeQueue = new ConcurrentLinkedQueue<Pair<InetSocketAddress, ByteBuffer>>();
-  private final ConcurrentLinkedQueue<SettableListenableFuture<Long>> writeFutures = new ConcurrentLinkedQueue<SettableListenableFuture<Long>>();
-  private final ConcurrentHashMap<InetAddress, Integer> filter = new ConcurrentHashMap<InetAddress, Integer>();
+  private final ConcurrentHashMap<InetSocketAddress, UDPClient> clients = new ConcurrentHashMap<>();
+  private final ConcurrentLinkedQueue<Pair<InetSocketAddress, ByteBuffer>> writeQueue = new ConcurrentLinkedQueue<>();
+  private final ConcurrentLinkedQueue<SettableListenableFuture<Long>> writeFutures = new ConcurrentLinkedQueue<>();
+  private final ConcurrentHashMap<InetAddress, Integer> filter = new ConcurrentHashMap<>();
   private final DatagramChannel channel;
   private volatile UDPFilterMode filterMode = UDPFilterMode.BlackList;
   private volatile UDPReader setUDPReader = null;
@@ -150,10 +150,10 @@ public class UDPServer extends Server {
   }
 
   @Override
-  public void close() {
+  protected void close(Throwable error) {
     if(setClosed()) {
       IOUtils.closeQuietly(channel);
-      this.callClosers();
+      this.callClosers(error);
     }
   }
 

--- a/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
+++ b/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
@@ -289,7 +289,8 @@ public class SSLProcessorTests {
     }
 
     @Override
-    protected void close(Throwable error) {
+    public void close(Throwable error) {
+      
     }
 
     @Override

--- a/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
+++ b/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
@@ -129,7 +129,6 @@ public class SSLProcessorTests {
 
     MergedByteBuffers dmbb = sp2.decrypt(mbb);
     assertEquals(STRING, dmbb.getAsString(dmbb.remaining()));
-    
   }
 
   @Test
@@ -175,7 +174,6 @@ public class SSLProcessorTests {
     
   }
 
-
   @Test
   public void largeEncrypted() throws IOException {
     FakeClient fc = new FakeClient(SE);
@@ -216,12 +214,9 @@ public class SSLProcessorTests {
       dmbb.add(tmpmbb);
     }
     assertEquals(LARGE_STRING, dmbb.getAsString(dmbb.remaining()));
-    
   }
   
-  
   public static class FakeClient extends Client {
-    
     MergedByteBuffers writeBuffers = new ReuseableMergedByteBuffers(false);
     SSLProcessor sp;
 
@@ -245,37 +240,31 @@ public class SSLProcessorTests {
 
     @Override
     public boolean hasConnectionTimedOut() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public ListenableFuture<Boolean> connect() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     protected void setConnectionStatus(Throwable t) {
-      // TODO Auto-generated method stub
       
     }
 
     @Override
     public void setConnectionTimeout(int timeout) {
-      // TODO Auto-generated method stub
       
     }
 
     @Override
     public int getTimeout() {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public int getWriteBufferSize() {
-      // TODO Auto-generated method stub
       return 0;
     }
 
@@ -286,37 +275,30 @@ public class SSLProcessorTests {
 
     @Override
     protected void reduceWrite(int size) {
-      // TODO Auto-generated method stub
       
     }
 
     @Override
     protected SocketChannel getChannel() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     public WireProtocol getProtocol() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
-    public void close() {
-      // TODO Auto-generated method stub
-      
+    protected void close(Throwable error) {
     }
 
     @Override
     public SocketAddress getRemoteSocketAddress() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     public SocketAddress getLocalSocketAddress() {
-      // TODO Auto-generated method stub
       return null;
     }
     
@@ -328,25 +310,21 @@ public class SSLProcessorTests {
 
     @Override
     public ClientOptions clientOptions() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     protected void doSocketRead(boolean doLocal) {
-      // TODO Auto-generated method stub
       
     }
 
     @Override
     protected void doSocketWrite(boolean doLocal) {
-      // TODO Auto-generated method stub
       
     }
 
     @Override
     public ListenableFuture<?> lastWriteFuture() {
-      // TODO Auto-generated method stub
       return null;
     }
 
@@ -355,8 +333,5 @@ public class SSLProcessorTests {
       writeBuffers.add(sp.encrypt(mbb));
       return FutureUtils.immediateResultFuture(true);
     }
-    
   }
-  
-  
 }

--- a/src/test/java/org/threadly/litesockets/tcp/FakeTCPServerClient.java
+++ b/src/test/java/org/threadly/litesockets/tcp/FakeTCPServerClient.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.threadly.litesockets.Client;
-import org.threadly.litesockets.Client.CloseListener;
+import org.threadly.litesockets.Client.ClientCloseListener;
 import org.threadly.litesockets.Client.Reader;
 import org.threadly.litesockets.Server;
 import org.threadly.litesockets.Server.ClientAcceptor;
@@ -15,8 +15,8 @@ import org.threadly.litesockets.buffers.ReuseableMergedByteBuffers;
 import org.threadly.litesockets.TCPClient;
 import org.threadly.litesockets.TCPServer;
 
-public class FakeTCPServerClient implements Reader, CloseListener, ClientAcceptor, ServerCloseListener{
-  private ConcurrentHashMap<TCPClient, MergedByteBuffers> map = new ConcurrentHashMap<TCPClient, MergedByteBuffers>();
+public class FakeTCPServerClient implements Reader, ClientCloseListener, ClientAcceptor, ServerCloseListener{
+  private ConcurrentHashMap<TCPClient, MergedByteBuffers> map = new ConcurrentHashMap<>();
   private ArrayList<TCPClient> clients = new ArrayList<TCPClient>();
   private ArrayList<TCPServer> servers = new ArrayList<TCPServer>();
 
@@ -107,5 +107,4 @@ public class FakeTCPServerClient implements Reader, CloseListener, ClientAccepto
 //      
 //    }
   }
-
 }

--- a/src/test/java/org/threadly/litesockets/tcp/TCPTests.java
+++ b/src/test/java/org/threadly/litesockets/tcp/TCPTests.java
@@ -27,7 +27,7 @@ import org.threadly.concurrent.future.FutureUtils;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.SettableListenableFuture;
 import org.threadly.litesockets.Client;
-import org.threadly.litesockets.Client.CloseListener;
+import org.threadly.litesockets.Client.ClientCloseListener;
 import org.threadly.litesockets.Client.Reader;
 import org.threadly.litesockets.buffers.MergedByteBuffers;
 import org.threadly.litesockets.buffers.ReuseableMergedByteBuffers;
@@ -124,7 +124,7 @@ public class TCPTests {
       assertFalse(client.clientOptions().setSocketRecvBuffer(1));
     }
     final SettableListenableFuture<Boolean> slf = new SettableListenableFuture<Boolean>(); 
-    client.addCloseListener(new CloseListener() {
+    client.addCloseListener(new ClientCloseListener() {
       @Override
       public void onClose(Client client) {
         slf.setResult(true);

--- a/src/test/java/org/threadly/litesockets/udp/FakeUDPServerClient.java
+++ b/src/test/java/org/threadly/litesockets/udp/FakeUDPServerClient.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.threadly.litesockets.Client;
 import org.threadly.litesockets.UDPClient;
 import org.threadly.litesockets.UDPServer;
-import org.threadly.litesockets.Client.CloseListener;
+import org.threadly.litesockets.Client.ClientCloseListener;
 import org.threadly.litesockets.Client.Reader;
 import org.threadly.litesockets.Server;
 import org.threadly.litesockets.Server.ClientAcceptor;
@@ -18,7 +18,7 @@ import org.threadly.litesockets.buffers.MergedByteBuffers;
 import org.threadly.litesockets.buffers.ReuseableMergedByteBuffers;
 import org.threadly.litesockets.SocketExecuter;
 
-public class FakeUDPServerClient implements CloseListener, Reader, ClientAcceptor, ServerCloseListener {
+public class FakeUDPServerClient implements ClientCloseListener, Reader, ClientAcceptor, ServerCloseListener {
   SocketExecuter SE;
   Set<UDPServer> servers = new HashSet<UDPServer>();
   ConcurrentHashMap<UDPClient, MergedByteBuffers> clients = new ConcurrentHashMap<UDPClient, MergedByteBuffers>();


### PR DESCRIPTION
This resolves #52 by allowing the `ExceptionUtils.handleException` behavior to be overriden / controlled.
By default the behavior will stay the same.  The ClientCloseListener and ServerCloseListener provide a default `onCloseWithError` implementation which will invoke into the ExceptionHandler before calling the normal `onClose`.  However if desired this default function can be overriden to avoid having the ExceptionHandler be invoked.

By having this be a default function it allows the CloseListener to still be able to be implemented with a lambda