### PR TITLE
MergedByteBuffers: Add `.add(MergedByteBuffers, int)` to specify copy size limit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.4-SNAPSHOT
-threadlyVersion = 5.20
+version = 4.4
+threadlyVersion = 5.24

--- a/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
@@ -67,12 +67,27 @@ public abstract class AbstractMergedByteBuffers implements MergedByteBuffers {
   @Override
   public void add(final MergedByteBuffers ...mbbs) {
     for(MergedByteBuffers mbb: mbbs) {
-      while(mbb.remaining() > 0) {
+      while(mbb.hasRemaining()) {
         ByteBuffer bb = mbb.popBuffer();
         if(bb.hasRemaining()) {
           doAppend(bb);
         }
       }
+    }
+  }
+
+  @Override
+  public void add(final MergedByteBuffers mbb, int maxLength) {
+    while(maxLength > 0 && mbb.hasRemaining()) {
+      int buffSize = mbb.nextBufferSize();
+      if (buffSize == 0) {
+        mbb.popBuffer();
+      } else if (buffSize <= maxLength) {
+        doAppend(mbb.popBuffer());
+      } else {
+        doAppend(mbb.pullBuffer(maxLength));
+      }
+      maxLength -= buffSize;
     }
   }
   

--- a/src/main/java/org/threadly/litesockets/buffers/MergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/MergedByteBuffers.java
@@ -48,6 +48,15 @@ public interface MergedByteBuffers {
   public void add(final MergedByteBuffers ...mbb);
   
   /**
+   * This method allows you to add a MergedByteBuffers to another MergedByteBuffers.  
+   * All must be done in order of how you want to pull the data back out.
+   * 
+   * @param mbb - The MergedByteBuffers to put into this MergedByteBuffers
+   * @param maxLength - Maximum number of bytes to copy out of provided mbb
+   */
+  public void add(MergedByteBuffers mbb, int maxLength);
+  
+  /**
    * Make a complete duplicate of this MergedByteBuffer.  Both references should function independently, but
    * they are still using the same ByteBuffer backing arrays so any change to the actual byte[] in the 
    * backing ByteBuffers will change in both.

--- a/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
@@ -137,7 +137,7 @@ public class ReuseableMergedByteBuffers extends AbstractMergedByteBuffers {
     if(first.remaining() == size) {
       return removeFirstBuffer().slice();
     } else if(first.remaining() > size) {
-      final ByteBuffer bb = first.duplicate().slice();
+      final ByteBuffer bb = first.duplicate();
       bb.limit(bb.position()+size);
       first.position(first.position()+size);
       return bb;

--- a/src/test/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffersTests.java
+++ b/src/test/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffersTests.java
@@ -9,6 +9,7 @@ import java.util.Random;
 
 import org.junit.After;
 import org.junit.Test;
+import org.threadly.util.StringUtils;
 
 public class ReuseableMergedByteBuffersTests {
   
@@ -27,6 +28,23 @@ public class ReuseableMergedByteBuffersTests {
     while (mbb.hasRemaining()) {
       assertEquals(bb.get(), mbb.get());
     }
+  }
+  
+  @Test
+  public void addMergedByteBuffersWithLimitTest() {
+    int size = 256;
+    ByteBuffer bb = ByteBuffer.wrap(StringUtils.makeRandomString(size).getBytes());
+    MergedByteBuffers mbbOut = new ReuseableMergedByteBuffers(false, bb);
+    MergedByteBuffers mbbIn = new ReuseableMergedByteBuffers(false);
+
+    assertEquals(size, mbbOut.remaining());
+    mbbIn.add(mbbOut, size / 2);
+    assertEquals(size / 2, mbbOut.remaining());
+    assertEquals(size / 2, mbbIn.remaining());
+
+    mbbIn.add(mbbOut, size / 2);
+    assertEquals(0, mbbOut.remaining());
+    assertEquals(size, mbbIn.remaining());
   }
   
   @Test


### PR DESCRIPTION
This is useful in case you only want to copy a portion between the buffers.  Without being able to specify a size limit it may require an extra copy to limit the size.