### PR TITLE
Client: Synchronize addReadBuffer to ensure it's not run concurrently with getRead()

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Include the litesockets library into your project from maven central:
 <dependency>
 	<groupId>org.threadly</groupId>
 	<artifactId>litesockets</artifactId>
-	<version>4.4</version>
+	<version>4.5</version>
 </dependency>
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.4
+version = 4.5
 threadlyVersion = 5.24

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -40,6 +40,7 @@ public class TCPClient extends Client {
   private final ReuseableMergedByteBuffers writeBuffers = new ReuseableMergedByteBuffers();
   private final Deque<Pair<Long, SettableListenableFuture<Long>>> writeFutures = new ArrayDeque<>(8);
   private final TCPSocketOptions tso = new TCPSocketOptions();
+  protected final Object writerLock = new Object();
   protected final AtomicBoolean startedConnection = new AtomicBoolean(false);
   protected final SettableListenableFuture<Boolean> connectionFuture;
   protected final SocketChannel channel;


### PR DESCRIPTION
`getRead()` typically is invoked on the client thread, and when used that way this should not be a concern.
However if you are not on the reader thread there is the potential for it to try and read while a write is being added.  This is a use case we want to continue to support, so this fixes it by locking while the read is being added.