### PR TITLE
SSLUtils: Accept String's in addition to File's

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.5
-threadlyVersion = 5.24
+version = 4.6
+threadlyVersion = 5.25

--- a/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
+++ b/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
@@ -262,7 +262,7 @@ public class SSLProcessorTests {
 
     @Override
     public int getTimeout() {
-      return 0;
+      return 10;
     }
 
     @Override


### PR DESCRIPTION
The motivation for this is that File's are not always available.  String's are more generic.  A common example is when the key's are combined into the classpath and thus a file can't be referenced easily (at least not without writing to a temp file).