### PR TITLE
SSLProcessor: Fix for possible infinite loop

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.6
-threadlyVersion = 5.25
+version = 4.7
+threadlyVersion = 5.27

--- a/src/main/java/org/threadly/litesockets/utils/SSLProcessor.java
+++ b/src/main/java/org/threadly/litesockets/utils/SSLProcessor.java
@@ -149,6 +149,8 @@ public class SSLProcessor {
         }
         if(!finishedHandshake.get() && res.getHandshakeStatus() == FINISHED) {
           gotFinished = true;
+        } else if (res.getStatus() == SSLEngineResult.Status.CLOSED) {
+          throw new EncryptionException("got ssl close_notify closing connection");
         } else {
           while (ssle.getHandshakeStatus() == NEED_TASK) {
             runTasks();
@@ -265,10 +267,14 @@ public class SSLProcessor {
    *
    */
   public static class EncryptionException extends Exception {
-
     private static final long serialVersionUID = -2713992763314654069L;
+    
     public EncryptionException(final Throwable t) {
       super(t);
+    }
+
+    public EncryptionException(String msg) {
+      super(msg);
     }
   }
 }


### PR DESCRIPTION
If the only (or all of) the nio threads are in this loop, they may not recognize a remote connection close
So the break here may not function without also checking the status of the ssl wrap.
The existing client close check is still needed in order to detect local closes