### PR TITLE
added udpServer/Client direct write options, fixed issue with udp non…

### DIFF
--- a/build.upload
+++ b/build.upload
@@ -20,11 +20,11 @@ compileJava {
   for (String path : java8Paths) {
     if (new java.io.File(path).exists()) {
       println 'Using java 8: ' + path
-      options.bootClasspath = fileTree(include: ['*.jar'], dir: path).join(File.pathSeparator)
+      options.bootstrapClasspath = fileTree(include: ['*.jar'], dir: path)
       break
     }
   }
-  if (options.bootClasspath == null) {
+  if (options.bootstrapClasspath == null) {
     println 'Unable to find java 8 rt.jar, will cause failure so exiting now'
     println ''
     System.exit(1)
@@ -46,11 +46,12 @@ compileTestJava {
   java8Paths[8] = "/usr/lib/jvm/jdk1.8.0_20/jre/lib/"
   for (String path : java8Paths) {
     if (new java.io.File(path).exists()) {
-      options.bootClasspath = fileTree(include: ['*.jar'], dir: path).join(File.pathSeparator)
+      options.bootstrapClasspath = fileTree(include: ['*.jar'], dir: path)
       break
     }
   }
 }
+
 
 signing {
   sign configurations.archives

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.7
-threadlyVersion = 5.27
+version = 4.8
+threadlyVersion = 5.28

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -396,8 +396,6 @@ public abstract class Client implements Closeable {
           readerCaller = () -> reader.onRead(this);
           if (this.getReadBufferSize() > 0) {
             callReader(false);  // we can't assume this is the reader thread
-          } else {
-            callReader(false);  
           }
         }
       }

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -46,6 +46,7 @@ public abstract class Client implements Closeable {
   protected volatile Runnable readerCaller = null;
   protected volatile boolean useNativeBuffers = false;
   protected volatile boolean keepReadBuffer = true;
+  protected volatile boolean directUdpWrites = false;
   protected volatile int maxBufferSize = IOUtils.DEFAULT_CLIENT_MAX_BUFFER_SIZE;
   protected volatile int newReadBufferSize = IOUtils.DEFAULT_CLIENT_READ_BUFFER_SIZE;
   private ByteBuffer readByteBuffer = IOUtils.EMPTY_BYTEBUFFER;
@@ -54,12 +55,12 @@ public abstract class Client implements Closeable {
     this.se = se;
     this.clientExecutor = se.getExecutorFor(this);
   }
-  
-  protected Client(final SocketExecuterCommonBase se, final SubmitterExecutor clientExecutor) {
+
+  protected Client(final SocketExecuterCommonBase se, final SubmitterExecutor lclientExecutor) {
     this.se = se;
-    this.clientExecutor = clientExecutor;
+    this.clientExecutor = lclientExecutor;
   }
-  
+
   protected <T> SettableListenableFuture<T> makeClientSettableListenableFuture() {
     return new ClientSettableListenableFuture<>(clientExecutor);
   }
@@ -100,13 +101,13 @@ public abstract class Client implements Closeable {
    * @return the {@link SocketChannel}  for this client.
    */
   protected abstract SocketChannel getChannel();
-  
+
   /**
    * This is called when the SocketExecuter detects the socket can read.  This must be done on the clients ReadThread, 
    * and not the thread calling this. 
    */
   protected abstract void doSocketRead(boolean doLocal);
-  
+
   /**
    * This is called when the SocketExecuter detects the socket can write.  This must be done on the clients ReadThread, 
    * and not the thread calling this. 
@@ -159,7 +160,7 @@ public abstract class Client implements Closeable {
    * @param timeout the time in milliseconds to wait for the client to connect.
    */
   public abstract void setConnectionTimeout(int timeout);
-  
+
   /**
    * <p>This tells us if the client has timed out before it has been connected to the socket.  
    * If the client has connected fully this will return false from that point on (even on a closed connection).</p>
@@ -200,7 +201,7 @@ public abstract class Client implements Closeable {
    * @return A {@link ListenableFuture} that will be completed once the data has been fully written to the socket.
    */
   public abstract ListenableFuture<?> write(ByteBuffer bb);
-  
+
   /**
    * <p>This is called to write data to the clients socket.  Its important to note that there is no back
    * pressure when adding writes so care should be taken to now allow the clients {@link #getWriteBufferSize()} to get
@@ -210,7 +211,7 @@ public abstract class Client implements Closeable {
    * @return A {@link ListenableFuture} that will be completed once the data has been fully written to the socket.
    */
   public abstract ListenableFuture<?> write(MergedByteBuffers mbb);
-  
+
   public abstract ListenableFuture<?> lastWriteFuture();
 
   /**
@@ -220,7 +221,7 @@ public abstract class Client implements Closeable {
   public void close() {
     close(null);
   }
-  
+
   /**
    * <p>Closes this client.  Reads can still occur after this it called.  {@link ClientCloseListener#onClose(Client)} will still be
    * called (if set) once all reads are done.</p>
@@ -230,7 +231,7 @@ public abstract class Client implements Closeable {
   public abstract void close(Throwable error);
 
   /*Implemented functions*/
-  
+
   protected void addReadStats(final int size) {
     stats.addRead(size);
   }
@@ -277,14 +278,14 @@ public abstract class Client implements Closeable {
       }
     }, invokedOnClientThread);
   }
-  
+
   protected void callReader(boolean invokedOnClientThread) {
     Runnable readerCaller = this.readerCaller;
     if (readerCaller != null) {
       runListener(readerCaller, invokedOnClientThread);
     }
   }
-  
+
   private void runListener(Runnable listener, boolean invokedOnClientThread) {
     if (invokedOnClientThread) {
       try {
@@ -395,6 +396,8 @@ public abstract class Client implements Closeable {
           readerCaller = () -> reader.onRead(this);
           if (this.getReadBufferSize() > 0) {
             callReader(false);  // we can't assume this is the reader thread
+          } else {
+            callReader(false);  
           }
         }
       }
@@ -673,8 +676,24 @@ public abstract class Client implements Closeable {
      * @return frame size in bytes.
      */
     public int getUdpFrameSize();
+
+    /**
+     * Direct writes are used for UDPClients.  This will cause a write w/o using the selector to deal
+     * with buffering.  This allows for much more control on timing, but also could easily allow
+     * overwriting of the socket buffer causing dropped packets.
+     * 
+     * @return true if directWrites are enabled, false if they are disabled.
+     */
+    public boolean directUdpWrites();
+
+    /**
+     * Set if directWrites are enabled or disabled on this client.
+     * 
+     * @param dw set to true to enable, anf false to disable.
+     */
+    public void setDirectUdpWrites(boolean dw);
   }
-  
+
   protected class BaseClientOptions implements ClientOptions {
     @Override
     public boolean setNativeBuffers(boolean enabled) {
@@ -761,6 +780,16 @@ public abstract class Client implements Closeable {
     @Override
     public int getUdpFrameSize() {
       return -1;
+    }
+
+    @Override
+    public boolean directUdpWrites() {
+      return directUdpWrites;
+    }
+
+    @Override
+    public void setDirectUdpWrites(boolean dw) {
+      directUdpWrites = dw;
     }
   }
 }

--- a/src/main/java/org/threadly/litesockets/UDPServer.java
+++ b/src/main/java/org/threadly/litesockets/UDPServer.java
@@ -9,10 +9,10 @@ import java.nio.channels.SelectableChannel;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.threadly.concurrent.future.FutureUtils;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.future.SettableListenableFuture;
 import org.threadly.litesockets.utils.IOUtils;
-import org.threadly.util.Pair;
 
 
 /**
@@ -32,14 +32,11 @@ public class UDPServer extends Server {
   /**
    * UDPFilter enum.
    * 
-   * @author lwahlmeier
-   *
    */
   public static enum UDPFilterMode {WhiteList, BlackList};
 
   private final ConcurrentHashMap<InetSocketAddress, UDPClient> clients = new ConcurrentHashMap<>();
-  private final ConcurrentLinkedQueue<Pair<InetSocketAddress, ByteBuffer>> writeQueue = new ConcurrentLinkedQueue<>();
-  private final ConcurrentLinkedQueue<SettableListenableFuture<Long>> writeFutures = new ConcurrentLinkedQueue<>();
+  private final ConcurrentLinkedQueue<WriteData> writeQueue = new ConcurrentLinkedQueue<>();
   private final ConcurrentHashMap<InetAddress, Integer> filter = new ConcurrentHashMap<>();
   private final DatagramChannel channel;
   private volatile UDPFilterMode filterMode = UDPFilterMode.BlackList;
@@ -158,16 +155,15 @@ public class UDPServer extends Server {
   }
 
   protected int doWrite() {
-    Pair<InetSocketAddress, ByteBuffer> wdp = writeQueue.poll();
-    SettableListenableFuture<Long> slf = writeFutures.poll();
-    if(wdp != null) {
+    WriteData wd = writeQueue.poll();
+    if(wd != null) {
       try {
-        return channel.send(wdp.getRight(), wdp.getLeft());
+        return channel.send(wd.getBuffer(), wd.getAddress());
       } catch (IOException e) {
         return 0;
       } finally {
-        if(slf != null) {
-          slf.setResult(0L);
+        if(wd.getSlf() != null && !wd.getSlf().isDone()) {
+          wd.getSlf().setResult(0L);
         }
       }
     }
@@ -177,7 +173,7 @@ public class UDPServer extends Server {
   protected boolean needsWrite() {
     return !writeQueue.isEmpty();
   }
-  
+
   protected SocketExecuterCommonBase getSocketExecuterCommonBase() {
     return sei;
   }
@@ -192,10 +188,30 @@ public class UDPServer extends Server {
    */
   public ListenableFuture<Long> write(final ByteBuffer bb, final InetSocketAddress remoteAddress) {
     SettableListenableFuture<Long> slf = new SettableListenableFuture<Long>();
-    this.writeFutures.add(slf);
-    writeQueue.add(new Pair<InetSocketAddress, ByteBuffer>(remoteAddress, bb));
+    WriteData wd = new WriteData(slf, remoteAddress, bb);
+    this.writeQueue.add(wd);
     getSocketExecuter().setUDPServerOperations(this, true);
     return slf;
+  }
+
+  /**
+   * Write the buffer immediately to the channel.  This write is not added to the write queue and processed when
+   * we know we can write a udpPacket.  This can allow for better timing on your writes when you need it, but
+   * can also cause problem is this is called many times in a row with no regard for socket buffers as udp
+   * will drop packets. 
+   * 
+   * @param bb the buffer to write.
+   * @param remoteAddress the address to write too.
+   * @return a future with the result of the write.  This will be completed.
+   */
+  public ListenableFuture<Long> writeDirect(final ByteBuffer bb, final InetSocketAddress remoteAddress) {
+    long size = 0;
+    try {
+      size = channel.send(bb, remoteAddress);
+    } catch (IOException e) {
+      return FutureUtils.immediateFailureFuture(e);
+    }
+    return FutureUtils.immediateResultFuture(size);
   }
 
   /**
@@ -274,7 +290,7 @@ public class UDPServer extends Server {
    *
    */
   public interface UDPReader {
-    
+
     /**
      * This is called whenever the UDPServer reads data from the socket.
      * 
@@ -283,5 +299,31 @@ public class UDPServer extends Server {
      * @return true if the data should be passed onto the UDPClient, false if it should not be.
      */
     public boolean onUDPRead(ByteBuffer bb, InetSocketAddress isa);
+  }
+
+  private static class WriteData {
+
+    private final SettableListenableFuture<Long> slf;
+    private final InetSocketAddress address;
+    private final ByteBuffer buffer;
+
+    public WriteData(SettableListenableFuture<Long> slf, InetSocketAddress address, ByteBuffer buffer) {
+      this.slf = slf;
+      this.address = address;
+      this.buffer = buffer;
+    }
+
+    public SettableListenableFuture<Long> getSlf() {
+      return slf;
+    }
+
+    public InetSocketAddress getAddress() {
+      return address;
+    }
+
+    public ByteBuffer getBuffer() {
+      return buffer;
+    }
+
   }
 }

--- a/src/test/java/org/threadly/litesockets/udp/UDPTest.java
+++ b/src/test/java/org/threadly/litesockets/udp/UDPTest.java
@@ -139,6 +139,37 @@ public class UDPTest {
     newServer.close();
   }  
   
+  @Test
+  public void simpleUDPDirectWriteTest() throws IOException {
+    final int newPort = PortUtils.findUDPPort();
+    final FakeUDPServerClient newFC = new FakeUDPServerClient(SE);
+    final UDPServer newServer = SE.createUDPServer("localhost", newPort);
+    newFC.AddUDPServer(newServer);
+    final UDPClient c = newServer.createUDPClient("127.0.0.1", port);
+    c.clientOptions().setDirectUdpWrites(true);
+    newFC.accept(c);
+    c.write(ByteBuffer.wrap(GET.getBytes()));
+    new TestCondition(){
+      @Override
+      public boolean get() {
+        return serverFC.clientList.size() == 1;
+      }
+    }.blockTillTrue(5000);
+    final UDPClient rc = serverFC.clientList.get(0);
+    rc.clientOptions().setDirectUdpWrites(true);
+    new TestCondition(){
+      @Override
+      public boolean get() {
+        return serverFC.clients.get(rc).remaining() > 0;
+      }
+    }.blockTillTrue(5000);
+    System.out.println(serverFC.clients.get(rc).remaining());
+    assertEquals(GET, serverFC.clients.get(rc).getAsString(serverFC.clients.get(rc).remaining()));
+    newServer.close();
+    c.close();
+    newServer.close();
+  }  
+  
   
   @Test
   public void simpleUDPTestNativeBuffers() throws IOException {


### PR DESCRIPTION
* added in DirectWrite support for udp client/server.  This allows you to write to a udp socket w/o having to use the selector.  Since UDP will just drop packets if you overfill its socket buffer timing and buffering have to be handled by the implementor.  This is more for RTC type communication since its more important to reduce delay to socket then guarantee delivery.
* Fixed non-direct write issue in UDPServer, where the server could mixup the settableListeneeablefuture and the buffer its was tied too if more then one write came in on multiple clients for that server.