### PR TITLE
Fix write bug

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.8
-threadlyVersion = 5.28
+version = 4.9
+threadlyVersion = 5.29

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -179,7 +179,7 @@ public class TCPClient extends Client {
 
   @Override
   public boolean canWrite() {
-    return writeBuffers.remaining() > 0 ;
+    return writeBuffers.remaining() + this.currentWriteBuffer.remaining() > 0 ;
   }
 
   @Override


### PR DESCRIPTION
@jentfoo found a small bug in tcp client .canWrite().  Basically there are race conditions where if a larger BB is written, and the first time we write to the socket we do not write the whole buffer we  might not add the tcpClient  back into the needsWrite poll, and wont ever try to write with it again until we get another .write()