### PR TITLE
Client: Add the ability to disable stats

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
 version = 4.10-SNAPSHOT
-threadlyVersion = 5.34
+threadlyVersion = 5.37

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -316,7 +316,7 @@ public abstract class Client implements Closeable {
       return;
     }
     recordReadStats(bb.remaining());
-    se.recordReadStatst(bb.remaining());
+    se.recordReadStats(bb.remaining());
     int start;
     // synchronize to ensure readBuffers are not modified by non-client thread getRead call
     synchronized (readerLock) {

--- a/src/main/java/org/threadly/litesockets/Client.java
+++ b/src/main/java/org/threadly/litesockets/Client.java
@@ -124,13 +124,11 @@ public abstract class Client implements Closeable {
    */
   public abstract SocketAddress getRemoteSocketAddress();
 
-
   /**
    * 
    * @return the local {@link SocketAddress} this client is using.
    */
   public abstract SocketAddress getLocalSocketAddress();
-
 
   /**
    * Returns true if this client has data pending in its write buffers.  False if there is no data pending write.
@@ -519,7 +517,6 @@ public abstract class Client implements Closeable {
      */
     public void onRead(Client client);
   }
-
 
   /**
    * Used to notify when a Client is closed.

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -40,7 +40,15 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
    * Constructs a NoThreadSocketExecuter.  {@link #start()} must still be called before using it.
    */
   public NoThreadSocketExecuter() {
-    super(new NoThreadScheduler());
+    this(new NoThreadScheduler()); 
+  }
+  
+  /**
+   * Constructs a NoThreadSocketExecuter.  {@link #start()} must still be called before using it.
+   */
+  public NoThreadSocketExecuter(NoThreadScheduler scheduler) {
+    super(scheduler);
+
     localNoThreadScheduler = (NoThreadScheduler)schedulerPool; 
   }
 

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -219,7 +219,7 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
                     if(server != null) {
                       if(server instanceof UDPServer) {
                         UDPServer us = (UDPServer) server;
-                        stats.addWrite(us.doWrite());
+                        recordWriteStats(us.doWrite());
                         setUDPServerOperations(us, true);
                       }
                     }

--- a/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/NoThreadSocketExecuter.java
@@ -88,8 +88,6 @@ public class NoThreadSocketExecuter extends SocketExecuterCommonBase {
   protected void startupService() {
     commonSelector = openSelector();
     this.acceptSelector = commonSelector;
-    this.readSelector = commonSelector;
-    this.writeSelector = commonSelector;
   }
 
   @Override

--- a/src/main/java/org/threadly/litesockets/SingleThreadSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/SingleThreadSocketExecuter.java
@@ -1,35 +1,69 @@
 package org.threadly.litesockets;
 
-import org.threadly.concurrent.SingleThreadScheduler;
+import org.threadly.concurrent.ConfigurableThreadFactory;
+import org.threadly.concurrent.NoThreadScheduler;
+import org.threadly.util.ExceptionUtils;
 
 /**
- * This is a SingleThreaded implementation of a SocketExecuter. 
- * 
- * 
- *
+ * This is a SingleThreaded implementation of a SocketExecuter.  If single threaded performance is 
+ * desired it should be slightly less overhead than a {@link ThreadedSocketExecuter}.
  */
 public class SingleThreadSocketExecuter extends NoThreadSocketExecuter {
   private static final int SELECT_TIME_MS = 10000;
+  private static final ConfigurableThreadFactory THREAD_FACTORY = 
+      new ConfigurableThreadFactory("SingleThreadSocketExecuter-", false, true, 
+                                    Thread.currentThread().getPriority(), null, null);
   
-  private final SingleThreadScheduler sts = new SingleThreadScheduler();
-  
+  private Thread runningThread = null;
+
+  /**
+   * Constructs a SingleThreadSocketExecuter.  {@link #start()} must still be called before using it.
+   */
   public SingleThreadSocketExecuter() {
     super();
+  }
+
+  /**
+   * Constructs a SingleThreadSocketExecuter.  {@link #start()} must still be called before using it.
+   * <p>
+   * This accepts a {@link NoThreadScheduler} so that stats can be collected if desired.
+   */
+  public SingleThreadSocketExecuter(NoThreadScheduler scheduler) {
+    super(scheduler);
   }
   
   @Override
   protected void startupService() {
     super.startupService();
-    sts.execute(()->{
+    runningThread = THREAD_FACTORY.newThread(()->{
       while(isRunning()) {
-        super.select(SELECT_TIME_MS);
+        try {
+          super.select(SELECT_TIME_MS);
+        } catch (Throwable t) {
+          ExceptionUtils.handleException(t);
+        }
       }
     });
+    runningThread.start();
   }
   
+  @Override
+  protected void shutdownService() {
+    super.shutdownService();
+    
+    try {
+      runningThread.join();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
   public void select() {
   }
 
+  @Override
   public void select(int delay) {
   }
 }

--- a/src/main/java/org/threadly/litesockets/SocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuter.java
@@ -29,6 +29,23 @@ public interface SocketExecuter extends Service {
    */
   public void setPerConnectionStatsEnabled(boolean enabled);
   
+  
+  /**
+   * Check the total number of bytes pending to be sent by clients.  This is data which has been 
+   * provided to the client to write, but is waiting on the network and kernel to accept the write.
+   * 
+   * @return The total number of bytes pending to write by clients
+   */
+  public long getTotalPendingWriteBytes();
+  
+  /**
+   * Check the total amount of pending reads across all associated clients.  Bytes here indicate 
+   * that the client has been notified a read is available but has not consumed it.
+   * 
+   * @return The total number of bytes pending to read by clients
+   */
+  public long getTotalPendingReadBytes();
+  
   /**
    * This will create a UDPServer on the specified {@link SocketExecuter}.
    * 

--- a/src/main/java/org/threadly/litesockets/SocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuter.java
@@ -21,6 +21,13 @@ import org.threadly.util.Service;
  *
  */
 public interface SocketExecuter extends Service {
+  /**
+   * By default per-connection stats will be enabled.  Stats can always be disabled on a per-Client 
+   * basis, but this allows the default state of the stats to be enabled / disabled.
+   * 
+   * @param enabled {@code false} if stats should not be collected per-connection by default
+   */
+  public void setPerConnectionStatsEnabled(boolean enabled);
   
   /**
    * This will create a UDPServer on the specified {@link SocketExecuter}.

--- a/src/main/java/org/threadly/litesockets/SocketExecuterCommonBase.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuterCommonBase.java
@@ -23,39 +23,28 @@ import org.threadly.util.ArgumentVerifier;
  *  This is a common base class for the Threaded and NoThread SocketExecuters. 
  */
 abstract class SocketExecuterCommonBase extends AbstractService implements SocketExecuter {
-  private final Logger log = Logger.getLogger(this.getClass().toString());
-  protected final SubmitterScheduler acceptScheduler;
-  protected final SubmitterScheduler readScheduler;
-  protected final SubmitterScheduler writeScheduler;
+  protected final Logger log = Logger.getLogger(this.getClass().toString());
   protected final SubmitterScheduler schedulerPool;
+  protected final SubmitterScheduler acceptScheduler;
   protected final ConcurrentHashMap<SocketChannel, Client> clients = new ConcurrentHashMap<>();
   protected final ConcurrentHashMap<SelectableChannel, Server> servers = new ConcurrentHashMap<>();
   protected final SocketExecuterByteStats stats = new SocketExecuterByteStats();
   protected final WatchdogCache dogCache;
   protected volatile boolean perConnectionStatsEnabled = true;
-  protected volatile boolean verboseLogging = false;
-  protected Selector readSelector;
-  protected Selector writeSelector;
   protected Selector acceptSelector;
 
   SocketExecuterCommonBase(final SubmitterScheduler scheduler) {
-    this(scheduler,scheduler,scheduler,scheduler);
+    this(scheduler, scheduler);
   }
 
-  SocketExecuterCommonBase(final SubmitterScheduler acceptScheduler, 
-      final SubmitterScheduler readScheduler, 
-      final SubmitterScheduler writeScheduler, 
-      final SubmitterScheduler ssi) {
+  SocketExecuterCommonBase(final SubmitterScheduler acceptScheduler, final SubmitterScheduler ssi) {
     log.setParent(Logger.getGlobal());
     ArgumentVerifier.assertNotNull(ssi, "ThreadScheduler");    
     ArgumentVerifier.assertNotNull(acceptScheduler, "Accept Scheduler");
-    ArgumentVerifier.assertNotNull(readScheduler, "Read Scheduler");
-    ArgumentVerifier.assertNotNull(writeScheduler, "Write Scheduler");
+    
     schedulerPool = ssi;
     dogCache = new WatchdogCache(ssi, true);
     this.acceptScheduler = acceptScheduler;
-    this.readScheduler = readScheduler;
-    this.writeScheduler = writeScheduler;
   }
 
   public void setPerConnectionStatsEnabled(boolean enabled) {

--- a/src/main/java/org/threadly/litesockets/SocketExecuterCommonBase.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuterCommonBase.java
@@ -51,7 +51,7 @@ abstract class SocketExecuterCommonBase extends AbstractService implements Socke
     perConnectionStatsEnabled = enabled;
   }
 
-  protected void recordReadStatst(int size) {
+  protected void recordReadStats(int size) {
     stats.addRead(size);
   }
 

--- a/src/main/java/org/threadly/litesockets/SocketExecuterCommonBase.java
+++ b/src/main/java/org/threadly/litesockets/SocketExecuterCommonBase.java
@@ -47,6 +47,25 @@ abstract class SocketExecuterCommonBase extends AbstractService implements Socke
     this.acceptScheduler = acceptScheduler;
   }
 
+  @Override
+  public long getTotalPendingWriteBytes() {
+    long result = 0;
+    for (Client c : clients.values()) {
+      result += c.getWriteBufferSize();
+    }
+    return result;
+  }
+  
+  @Override
+  public long getTotalPendingReadBytes() {
+    long result = 0;
+    for (Client c : clients.values()) {
+      result += c.getReadBufferSize();
+    }
+    return result;
+  }
+
+  @Override
   public void setPerConnectionStatsEnabled(boolean enabled) {
     perConnectionStatsEnabled = enabled;
   }

--- a/src/main/java/org/threadly/litesockets/ThreadedSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/ThreadedSocketExecuter.java
@@ -310,7 +310,7 @@ public class ThreadedSocketExecuter extends SocketExecuterCommonBase {
                     if(server != null) {
                       if(server instanceof UDPServer) {
                         UDPServer us = (UDPServer) server;
-                        stats.addWrite(us.doWrite());
+                        recordWriteStats(us.doWrite());
                         setUDPServerOperations(us, true);
                       }
                     }

--- a/src/main/java/org/threadly/litesockets/ThreadedSocketExecuter.java
+++ b/src/main/java/org/threadly/litesockets/ThreadedSocketExecuter.java
@@ -28,7 +28,6 @@ import org.threadly.util.ExceptionUtils;
 public class ThreadedSocketExecuter extends SocketExecuterCommonBase {
   private final SelectorThread[] clientSelectors;
   private final KeyDistributedExecutor clientDistributer;
-  private final int selectors;
   
   /**
    * <p>This constructor creates its own {@link SingleThreadScheduler} Threadpool to use for client operations.  This is generally 
@@ -79,22 +78,22 @@ public class ThreadedSocketExecuter extends SocketExecuterCommonBase {
    */
   public ThreadedSocketExecuter(final SubmitterScheduler scheduler, final int maxTasksPerCycle, final int numberOfSelectors) {
     super(scheduler);
+    
     int ps = -1;
-    if(numberOfSelectors == -1) {
-       ps = Math.max(1,  Runtime.getRuntime().availableProcessors()/2);
+    if(numberOfSelectors <= 0) {
+      ps = Math.max(1,  Runtime.getRuntime().availableProcessors()/2);
     } else {
       ps = numberOfSelectors;
     }
     clientSelectors = new SelectorThread[ps];
     clientDistributer = new KeyDistributedExecutor(schedulerPool, maxTasksPerCycle);
-    this.selectors = ps;
   }
   
   private SelectorThread getSelectorFor(Object obj) {
-    if(selectors == 1) {
+    if(clientSelectors.length == 1) {
       return clientSelectors[0];
     } 
-    return clientSelectors[obj.hashCode()%selectors];
+    return clientSelectors[obj.hashCode() % clientSelectors.length];
   }
 
   @Override
@@ -142,7 +141,7 @@ public class ThreadedSocketExecuter extends SocketExecuterCommonBase {
 
   @Override
   protected void startupService() {
-    for(int i=0; i<selectors; i++) {
+    for(int i=0; i < clientSelectors.length; i++) {
       clientSelectors[i] = new SelectorThread(i);
     }
   }

--- a/src/main/java/org/threadly/litesockets/UDPServer.java
+++ b/src/main/java/org/threadly/litesockets/UDPServer.java
@@ -236,7 +236,8 @@ public class UDPServer extends Server {
   public UDPClient createUDPClient(final String host, final int port) {
     final InetSocketAddress sa = new InetSocketAddress(host,port);
     if(! clients.containsKey(sa)) {
-      final UDPClient c = new UDPClient(new InetSocketAddress(host, port), this);
+      final UDPClient c = new UDPClient(new InetSocketAddress(host, port), this, 
+                                        sei.perConnectionStatsEnabled);
       clients.putIfAbsent(sa, c);
     }
     return clients.get(sa);
@@ -265,7 +266,7 @@ public class UDPServer extends Server {
       UDPReader reader = us.setUDPReader;
       if(reader == null || reader.onUDPRead(bb.duplicate(), isa)) {
         if(! us.clients.containsKey(isa)) {
-          UDPClient udpc = new UDPClient(isa, us);
+          UDPClient udpc = new UDPClient(isa, us, us.sei.perConnectionStatsEnabled);
           udpc = us.clients.putIfAbsent(isa, udpc);
           if(udpc == null) {
             udpc = us.clients.get(isa);

--- a/src/main/java/org/threadly/litesockets/utils/SimpleByteStats.java
+++ b/src/main/java/org/threadly/litesockets/utils/SimpleByteStats.java
@@ -9,18 +9,6 @@ import org.threadly.util.Clock;
  * Simple class for trying byteStats.  This implementation only tracks global stats. 
  */
 public class SimpleByteStats {
-  public static final SimpleByteStats NO_OP_BYTE_STAT_INSTANCE = new SimpleByteStats() {
-    @Override
-    protected void addWrite(final int size) {
-      // ignored
-    }
-    
-    @Override
-    protected void addRead(final int size) {
-      // ignored
-    }
-  };
-  
   private final LongAdder bytesRead = new LongAdder();
   private final LongAdder bytesWritten = new LongAdder();
   private volatile long startTime = Clock.lastKnownForwardProgressingMillis();

--- a/src/main/java/org/threadly/litesockets/utils/SimpleByteStats.java
+++ b/src/main/java/org/threadly/litesockets/utils/SimpleByteStats.java
@@ -2,27 +2,38 @@ package org.threadly.litesockets.utils;
 
 import java.util.concurrent.atomic.LongAdder;
 
+import org.threadly.util.ArgumentVerifier;
 import org.threadly.util.Clock;
-
 
 /**
  * Simple class for trying byteStats.  This implementation only tracks global stats. 
  */
 public class SimpleByteStats {
+  public static final SimpleByteStats NO_OP_BYTE_STAT_INSTANCE = new SimpleByteStats() {
+    @Override
+    protected void addWrite(final int size) {
+      // ignored
+    }
+    
+    @Override
+    protected void addRead(final int size) {
+      // ignored
+    }
+  };
+  
   private final LongAdder bytesRead = new LongAdder();
   private final LongAdder bytesWritten = new LongAdder();
-  
   private volatile long startTime = Clock.lastKnownForwardProgressingMillis();
-
-  public SimpleByteStats() {
-    //Nothing needed
-  }
   
   protected void addWrite(final int size) {
+    ArgumentVerifier.assertNotNegative(size, "size");
+    
     bytesWritten.add(size);
   }
   
   protected void addRead(final int size) {
+    ArgumentVerifier.assertNotNegative(size, "size");
+    
     bytesRead.add(size);
   }
   
@@ -41,7 +52,7 @@ public class SimpleByteStats {
   }
     
   /**
-   * @return the average rate per second that byte have been read, since creation.
+   * @return the average rate per second that byte have been read, since creation or {@link #resetStats()}
    */
   public double getReadRate() {
     final double sec = (Clock.lastKnownForwardProgressingMillis() - startTime)/1000.0;
@@ -49,7 +60,7 @@ public class SimpleByteStats {
   }
   
   /**
-   * @return the average rate per second that byte have been written, since creation.
+   * @return the average rate per second that byte have been written, since creation or {@link #resetStats()}
    */
   public double getWriteRate() {
     final double sec = (Clock.lastKnownForwardProgressingMillis() - startTime)/1000.0;
@@ -57,8 +68,8 @@ public class SimpleByteStats {
   }
   
   /**
-   * Resets all stats.
-   * 
+   * Resets all stats.  This can be particularly useful when using the 
+   * {@link #getReadRate()} / {@link #getWriteRate()}.
    */
   public void resetStats() {
     startTime = Clock.lastKnownForwardProgressingMillis();

--- a/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
+++ b/src/test/java/org/threadly/litesockets/SSLProcessorTests.java
@@ -11,7 +11,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.security.KeyStore;
 import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -231,7 +230,7 @@ public class SSLProcessorTests {
     SSLProcessor sp;
 
     public FakeClient(SocketExecuterCommonBase se) {
-      super(se);
+      super(se, true);
     }
 
     public void setSSLProcessor(SSLProcessor sp) {


### PR DESCRIPTION
These stats are fairly lightweight, but do incur some memory and computational overhead.
This change allows them to be disabled on a per-connection basis either as a setting change on the `SocketExecutor`, or on the `Client` itself.

I would in the future like to add additional stats, but have not arrived at what would be good to include.  Pool based stats might make sense, but those can be passed in when constructing the SocketExecutor.  Maybe stats around delays around notifying the selector and the selector waking up?  However I was unsure precisely how that would be useful.  @lwahlmeier let me know if you have thoughts around that, or this PR in general.