### PR TITLE
Don't .slice() ByteBuffers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
 version = 4.12-SNAPSHOT
-threadlyVersion = 5.40
+threadlyVersion = 5.41

--- a/src/main/java/org/threadly/litesockets/TCPClient.java
+++ b/src/main/java/org/threadly/litesockets/TCPClient.java
@@ -362,9 +362,9 @@ public class TCPClient extends Client {
       size = channel.read(readByteBuffer);
       if(size > 0) {
         readByteBuffer.position(origPos);
-        final ByteBuffer resultBuffer = readByteBuffer.slice();
+        final ByteBuffer resultBuffer = readByteBuffer.duplicate();
         readByteBuffer.position(origPos+size);
-        resultBuffer.limit(size);
+        resultBuffer.limit(resultBuffer.position()+size);
         addReadBuffer(resultBuffer);
         if(!doLocal) {
           se.setClientOperations(TCPClient.this);

--- a/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
@@ -59,7 +59,7 @@ public abstract class AbstractMergedByteBuffers implements MergedByteBuffers {
   public void add(final ByteBuffer ...buffers) {
     for(ByteBuffer buffer: buffers) {
       if(buffer.hasRemaining()) {
-        doAppend(buffer.slice());
+        doAppend(buffer.duplicate());
       }
     }
   }

--- a/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
@@ -135,7 +135,7 @@ public class ReuseableMergedByteBuffers extends AbstractMergedByteBuffers {
     currentSize -= size;
     final ByteBuffer first = availableBuffers.peek();
     if(first.remaining() == size) {
-      return removeFirstBuffer().slice();
+      return removeFirstBuffer();
     } else if(first.remaining() > size) {
       final ByteBuffer bb = first.duplicate();
       bb.limit(bb.position()+size);

--- a/src/main/java/org/threadly/litesockets/buffers/SimpleMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/SimpleMergedByteBuffers.java
@@ -140,7 +140,7 @@ public class SimpleMergedByteBuffers extends AbstractMergedByteBuffers {
     ByteBuffer bb = getNextBuffer();
     consumedSize += bb.remaining();
     currentBuffer++;
-    return bb.slice();
+    return bb.duplicate();
   }
 
   @Override
@@ -175,9 +175,9 @@ public class SimpleMergedByteBuffers extends AbstractMergedByteBuffers {
     final ByteBuffer first = getNextBuffer();
     if(first.remaining() == size) {
       currentBuffer++;
-      return first.slice();
+      return first.duplicate();
     } else if(first.remaining() > size) {
-      final ByteBuffer bb = first.duplicate().slice();
+      final ByteBuffer bb = first.duplicate();
       bb.limit(bb.position()+size);
       first.position(first.position()+size);
       return bb;

--- a/src/main/java/org/threadly/litesockets/buffers/TransactionalByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/TransactionalByteBuffers.java
@@ -159,6 +159,12 @@ public class TransactionalByteBuffers extends ReuseableMergedByteBuffers {
       super.discard(size);
     }
   }
+  
+  @Override
+  protected void doAppend(final ByteBuffer bb) {
+    // TODO - need to slice due to rollback logic requiring an absolute position of zero
+    super.doAppend(bb.slice());
+  }
 
   @Override
   protected ByteBuffer removeFirstBuffer() {


### PR DESCRIPTION
This stops doing .slice() operations on ByteBuffers, and instead uses only .duplicate().
The motivation for this is that .slice() makes the use of direct .array() access impossible.
It may be ideal to be able to access the array using the set position / limit so that a copy is not required in order to access the read data.