### PR TITLE
SimpleMergedByteBuffers: ArrayOutOfBounds Fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
-version = 4.12-SNAPSHOT
+version = 4.12
 threadlyVersion = 5.41

--- a/src/test/java/org/threadly/litesockets/buffers/SimpleMergedByteBuffersTests.java
+++ b/src/test/java/org/threadly/litesockets/buffers/SimpleMergedByteBuffersTests.java
@@ -62,7 +62,6 @@ public class SimpleMergedByteBuffersTests {
 
   @Test
   public void getInts() {
-    
     ByteBuffer[] bba = new ByteBuffer[200]; 
     for(int i = 0; i<200; i++) {
       ByteBuffer bb = ByteBuffer.allocate(4);
@@ -238,7 +237,6 @@ public class SimpleMergedByteBuffersTests {
   
   @Test
   public void popBuffer() {
-
     Random rnd = new Random();
     int size = Math.abs(rnd.nextInt(300))+10;
     MergedByteBuffers mbb = new SimpleMergedByteBuffers(false, ByteBuffer.allocate(size), ByteBuffer.allocate(rnd.nextInt(300)), ByteBuffer.allocate(rnd.nextInt(300)), ByteBuffer.allocate(rnd.nextInt(300)));


### PR DESCRIPTION
This fixes SimpleMergedByteBuffers.getNextBuffer to avoid an ArrayOutOfBounds fix when the buffer has been fully consumed.
We must always check the currentBuffer index before we can attempt to access the array.
In addition the EMPTY_BUFFER_ARRAY can not contain the empty buffer because it makes logic which compares the array length invalid.