### PR TITLE
SSL hang / timeout fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = org.threadly
 version = 4.13
-threadlyVersion = 5.41
+threadlyVersion = 5.42

--- a/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
@@ -31,7 +31,6 @@ public abstract class AbstractMergedByteBuffers implements MergedByteBuffers {
   }
   
   protected abstract void doAppend(final ByteBuffer bb);
-  protected abstract void addToFront(final ByteBuffer bb);
   protected abstract byte get(int pos);
   public abstract AbstractMergedByteBuffers duplicate();
   public abstract AbstractMergedByteBuffers duplicateAndClean();

--- a/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/AbstractMergedByteBuffers.java
@@ -58,9 +58,7 @@ public abstract class AbstractMergedByteBuffers implements MergedByteBuffers {
   @Override
   public void add(final ByteBuffer ...buffers) {
     for(ByteBuffer buffer: buffers) {
-      if(buffer.hasRemaining()) {
-        doAppend(buffer.duplicate());
-      }
+      doAppend(buffer);
     }
   }
 
@@ -68,10 +66,7 @@ public abstract class AbstractMergedByteBuffers implements MergedByteBuffers {
   public void add(final MergedByteBuffers ...mbbs) {
     for(MergedByteBuffers mbb: mbbs) {
       while(mbb.hasRemaining()) {
-        ByteBuffer bb = mbb.popBuffer();
-        if(bb.hasRemaining()) {
-          doAppend(bb);
-        }
+        doAppend(mbb.popBuffer());
       }
     }
   }

--- a/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
@@ -62,12 +62,6 @@ public class ReuseableMergedByteBuffers extends AbstractMergedByteBuffers {
   }
 
   @Override
-  protected void addToFront(ByteBuffer bb) {
-    this.availableBuffers.addFirst(bb);
-    this.currentSize+=bb.remaining();
-  }
-
-  @Override
   public int remaining() {
     return currentSize;
   }

--- a/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/ReuseableMergedByteBuffers.java
@@ -39,15 +39,17 @@ public class ReuseableMergedByteBuffers extends AbstractMergedByteBuffers {
   
   @Override
   protected void doAppend(final ByteBuffer bb) {
-    availableBuffers.add(bb);
-    currentSize+=bb.remaining();
+    if (bb.hasRemaining()) {
+      availableBuffers.add(bb.duplicate());
+      currentSize+=bb.remaining();
+    }
   }
 
   @Override
   public ReuseableMergedByteBuffers duplicate() {
     final ReuseableMergedByteBuffers mbb  = new ReuseableMergedByteBuffers(markReadOnly);
     for(final ByteBuffer bb: this.availableBuffers) {
-      mbb.add(bb.duplicate());
+      mbb.doAppend(bb);
     }
     return mbb;
   }
@@ -61,7 +63,7 @@ public class ReuseableMergedByteBuffers extends AbstractMergedByteBuffers {
 
   @Override
   protected void addToFront(ByteBuffer bb) {
-    this.availableBuffers.addFirst(bb.duplicate());
+    this.availableBuffers.addFirst(bb);
     this.currentSize+=bb.remaining();
   }
 

--- a/src/main/java/org/threadly/litesockets/buffers/SimpleMergedByteBuffers.java
+++ b/src/main/java/org/threadly/litesockets/buffers/SimpleMergedByteBuffers.java
@@ -77,11 +77,6 @@ public class SimpleMergedByteBuffers extends AbstractMergedByteBuffers {
   }
 
   @Override
-  protected void addToFront(ByteBuffer bb) {
-    throw new UnsupportedOperationException("Can not add to this buffer!");
-  }
-
-  @Override
   public SimpleMergedByteBuffers duplicate() {
     ByteBuffer[] bba2 = new ByteBuffer[bba.length-currentBuffer];
     for(int i=currentBuffer; i<bba.length; i++) {


### PR DESCRIPTION
This fixes ssl, which can be seen using litesockets-http-client when using https.  The behavior would be the start of the handshake which would eventually hang.
This regression was introduced in this PR: https://github.com/threadly/litesockets/pull/71
The specific flaw was introduced when the `.duplicate()` was removed here: https://github.com/threadly/litesockets/pull/71/files#diff-851d3597731b2cecc83331ede7aec7ebL143

It seems for SSL to work correctly we need to make sure that the MergedByteBuffer does not work against the original ByteBuffer that was originally passed in.
This fixes that behavior by making sure that when ByteBuffers are added (or provided at construction), we do this `.duplicate()` then.  This way when buffers are leaving the MergedByteBuffer we know it already has an independent experience from the one provided initially.  The goal being that by having this duplicate action happen at a consistent point will make this safer.
Overall I don't think we really add any `.duplicate()` actions, if anything at times we might have less.  With it happening at the start we can safely avoid duplicate calls at other points we had them previously.